### PR TITLE
Lower margin to 0.25

### DIFF
--- a/Extensions/RenderScripts/Shiandow.Deband.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.cs
@@ -9,7 +9,7 @@ namespace Mpdn.RenderScript
         public class Deband : RenderChain
         {
             private const float DEFAULT_THRESHOLD = 0.5f;
-            private const float DEFAULT_MARGIN = 1.0f;
+            private const float DEFAULT_MARGIN = 0.25f;
 
             public int maxbitdepth { get; set; }
             public float threshold { get; set; }


### PR DESCRIPTION
Setting the margin to 1.0 removes too much detail, the value 0.25 seems to be high enough to still remove banding.