### PR TITLE
Adding the UpdateChecker

### DIFF
--- a/Extensions/PlayerExtensions/UpdateChecker.ConfigDialog.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.ConfigDialog.cs
@@ -1,0 +1,46 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+using Mpdn.Config;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Forms;
+
+namespace Mpdn.PlayerExtensions.GitHub
+{
+    public partial class UpdateCheckerConfigDialog : UpdateCheckerConfigBase
+    {
+        public UpdateCheckerConfigDialog()
+        {
+            InitializeComponent();
+
+        }
+
+        protected override void LoadSettings()
+        {
+            checkBoxCheckUpdate.Checked = Settings.CheckForUpdate;
+        }
+
+        protected override void SaveSettings()
+        {
+            Settings.CheckForUpdate = checkBoxCheckUpdate.Checked;
+        }
+    }
+    public class UpdateCheckerConfigBase : ScriptConfigDialog<UpdateCheckerSettings>
+    {
+    }
+
+}

--- a/Extensions/PlayerExtensions/UpdateChecker.ConfigDialog.designer.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.ConfigDialog.designer.cs
@@ -1,0 +1,113 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+namespace Mpdn.PlayerExtensions.GitHub
+{
+    partial class UpdateCheckerConfigDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.buttonOk = new System.Windows.Forms.Button();
+            this.checkBoxCheckUpdate = new System.Windows.Forms.CheckBox();
+            this.SuspendLayout();
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(149, 59);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(75, 23);
+            this.buttonCancel.TabIndex = 1005;
+            this.buttonCancel.Text = "Cancel";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            // 
+            // buttonOk
+            // 
+            this.buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.buttonOk.Location = new System.Drawing.Point(68, 59);
+            this.buttonOk.Name = "buttonOk";
+            this.buttonOk.Size = new System.Drawing.Size(75, 23);
+            this.buttonOk.TabIndex = 1004;
+            this.buttonOk.Text = "OK";
+            this.buttonOk.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxCheckUpdate
+            // 
+            this.checkBoxCheckUpdate.AutoSize = true;
+            this.checkBoxCheckUpdate.Location = new System.Drawing.Point(22, 22);
+            this.checkBoxCheckUpdate.Name = "checkBoxCheckUpdate";
+            this.checkBoxCheckUpdate.Size = new System.Drawing.Size(137, 17);
+            this.checkBoxCheckUpdate.TabIndex = 1006;
+            this.checkBoxCheckUpdate.Text = "Check for new versions";
+            this.checkBoxCheckUpdate.UseVisualStyleBackColor = true;
+            // 
+            // UpdateCheckerConfigDialog
+            // 
+            this.AcceptButton = this.buttonOk;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(236, 94);
+            this.Controls.Add(this.checkBoxCheckUpdate);
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.buttonOk);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "UpdateCheckerConfigDialog";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "UpdateChecker Configuration";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.Button buttonOk;
+        private System.Windows.Forms.CheckBox checkBoxCheckUpdate;
+
+    }
+}

--- a/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
@@ -1,0 +1,268 @@
+﻿// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+using OpenSubtitles.PlayerExtensions;
+
+namespace Mpdn.PlayerExtensions.GitHub
+{
+    public class UpdateCheckerExtension : PlayerExtension<UpdateCheckerSettings, UpdateCheckerConfigDialog>
+    {
+        private UpdateChecker.Version m_currentVersion;
+        private UpdateChecker m_checker;
+
+        public override ExtensionUiDescriptor Descriptor
+        {
+            get
+            {
+                return new ExtensionUiDescriptor
+                {
+                    Guid = new Guid("9294ff0e-cbb1-49d4-9721-d1a438852968"),
+                    Name = "Update Checker",
+                    Description = "Check for new version of MPDN"
+                };
+            }
+        }
+
+        public override IList<Verb> Verbs
+        {
+            get
+            {
+                return new[]
+                {
+                    new Verb(Category.View, string.Empty, "Toggle Update Checker", "Ctrl+Shift+U", string.Empty,
+                        ToggleUpdateChecker)
+                };
+            }
+        }
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            m_checker = new UpdateChecker(Settings);
+            PlayerControl.PlayerLoaded += PlayerControl_PlayerLoaded;
+        }
+
+        private void PlayerControl_PlayerLoaded(object sender, EventArgs e)
+        {
+            if (!Settings.CheckForUpdate)
+                return;
+            m_currentVersion = new UpdateChecker.Version(Application.ProductVersion);
+            if (!Settings.ForgetVersion && Settings.VersionOnServer > m_currentVersion)
+            {
+                new UpdateCheckerNewVersionForm(Settings.VersionOnServer, Settings).ShowDialog(PlayerControl.Form);
+            }
+            m_checker.CheckVersion();
+
+        }
+
+        public override void Destroy()
+        {
+            base.Destroy();
+            PlayerControl.PlayerLoaded -= PlayerControl_PlayerLoaded;
+        }
+
+        private void ToggleUpdateChecker()
+        {
+            Settings.CheckForUpdate = !Settings.CheckForUpdate;
+        }
+    }
+
+    public class UpdateCheckerSettings
+    {
+        public UpdateCheckerSettings()
+        {
+            CheckForUpdate = true;
+            ForgetVersion = false;
+        }
+
+
+        public bool CheckForUpdate { get; set; }
+        public UpdateChecker.Version VersionOnServer { get; set; }
+        public bool ForgetVersion { get; set; }
+    }
+    #region UpdateChecker
+
+    public class UpdateChecker
+    {
+        private static readonly Uri ChangelogUrl = new Uri("http://mpdn.zachsaw.com/Latest/ChangeLog.txt");
+        public static readonly string WebsiteUrl = "http://mpdn.zachsaw.com/Latest/";
+        private readonly UpdateCheckerSettings m_settings;
+        private readonly WebClient m_WebClient = new WebClient();
+
+        public UpdateChecker(UpdateCheckerSettings settings)
+        {
+            m_settings = settings;
+            m_WebClient.DownloadStringCompleted += m_WebClient_DownloadStringCompleted;
+        }
+
+        private void m_WebClient_DownloadStringCompleted(object sender, DownloadStringCompletedEventArgs e)
+        {
+            string changelog;
+            try
+            {
+                changelog = e.Result;
+            }
+            catch (Exception)
+            {
+                return;
+            }
+          
+            Version serverVersion = null;
+            foreach (var line in Regex.Split(changelog, "\r\n|\r|\n"))
+            {
+                if (Version.VERSION_REGEX.IsMatch(line))
+                {
+                    if (serverVersion == null)
+                    {
+                        serverVersion = new Version(line);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                else if (serverVersion != null)
+                {
+                    serverVersion.Changelog += line.Trim() + Environment.NewLine;
+                }
+            }
+            if (m_settings.VersionOnServer != serverVersion)
+            {
+                m_settings.VersionOnServer = serverVersion;
+                m_settings.ForgetVersion = false;
+            }
+        }
+
+        public void CheckVersion()
+        {
+            m_WebClient.DownloadStringAsync(ChangelogUrl);
+        }
+
+        #region Version
+
+        public class Version
+        {
+            public static readonly Regex VERSION_REGEX = new Regex(@"([0-9]+)\.([0-9]+)\.([0-9]+)");
+
+            public Version()
+            {
+            }
+
+            public Version(string version)
+            {
+                var matches = VERSION_REGEX.Match(version);
+                Major = uint.Parse(matches.Groups[1].Value);
+                Minor = uint.Parse(matches.Groups[2].Value);
+                Revision = uint.Parse(matches.Groups[3].Value);
+            }
+
+            public uint Major { get; set; }
+            public uint Minor { get; set; }
+            public uint Revision { get; set; }
+            public string Changelog { get; set; }
+
+
+            public static bool operator >(Version v1, Version v2)
+            {
+                if (v1 == null)
+                    return false;
+                if (v2 == null)
+                    return true;
+                if (v1 == v2)
+                    return false;
+                if (v1.Major > v2.Major)
+                    return true;
+                if (v1.Minor > v2.Minor)
+                    return true;
+                if (v1.Revision > v2.Revision)
+                    return true;
+                return false;
+            }
+
+            public static bool operator <(Version v1, Version v2)
+            {
+                if (v1 == null)
+                    return true;
+                if (v2 == null)
+                    return false;
+                if (v1 == v2)
+                    return false;
+
+                if (v1.Major < v2.Major)
+                    return true;
+                if (v1.Minor < v2.Minor)
+                    return true;
+                if (v1.Revision < v2.Revision)
+                    return true;
+                return false;
+            }
+
+
+            public static bool operator ==(Version v1, Version v2)
+            {
+                if (ReferenceEquals(null, v1) && ReferenceEquals(null, v2))
+                    return true;
+                if (ReferenceEquals(null, v1) || ReferenceEquals(null, v2))
+                    return false;
+
+                return v1.Equals(v2);
+            }
+
+            public static bool operator !=(Version v1, Version v2)
+            {
+                return !(v1 == v2);
+            }
+
+            protected bool Equals(Version other)
+            {
+                return Major == other.Major && Minor == other.Minor && Revision == other.Revision;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((Version)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (int)Major;
+                    hashCode = (hashCode * 397) ^ (int)Minor;
+                    hashCode = (hashCode * 397) ^ (int)Revision;
+                    return hashCode;
+                }
+            }
+
+            public override string ToString()
+            {
+                return "v" + Major + "." + Minor + "." + Revision;
+            }
+        }
+
+        #endregion
+    }
+    #endregion
+}

--- a/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
-using OpenSubtitles.PlayerExtensions;
 
 namespace Mpdn.PlayerExtensions.GitHub
 {

--- a/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.Designer.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.Designer.cs
@@ -1,0 +1,105 @@
+﻿namespace OpenSubtitles.PlayerExtensions
+{
+    partial class UpdateCheckerNewVersionForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.downloadButton = new System.Windows.Forms.Button();
+            this.forgetUpdate = new System.Windows.Forms.Button();
+            this.CloseButton = new System.Windows.Forms.Button();
+            this.changelogBox = new System.Windows.Forms.RichTextBox();
+            this.SuspendLayout();
+            // 
+            // downloadButton
+            // 
+            this.downloadButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.downloadButton.Location = new System.Drawing.Point(337, 133);
+            this.downloadButton.Name = "downloadButton";
+            this.downloadButton.Size = new System.Drawing.Size(75, 23);
+            this.downloadButton.TabIndex = 0;
+            this.downloadButton.Text = "Download";
+            this.downloadButton.UseVisualStyleBackColor = true;
+            this.downloadButton.Click += new System.EventHandler(this.downloadButton_Click);
+            // 
+            // forgetUpdate
+            // 
+            this.forgetUpdate.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.forgetUpdate.Location = new System.Drawing.Point(169, 133);
+            this.forgetUpdate.Name = "forgetUpdate";
+            this.forgetUpdate.Size = new System.Drawing.Size(86, 23);
+            this.forgetUpdate.TabIndex = 1;
+            this.forgetUpdate.Text = "Forget Update";
+            this.forgetUpdate.UseVisualStyleBackColor = true;
+            this.forgetUpdate.Click += new System.EventHandler(this.forgetUpdate_Click);
+            // 
+            // CloseButton
+            // 
+            this.CloseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.CloseButton.Location = new System.Drawing.Point(12, 133);
+            this.CloseButton.Name = "CloseButton";
+            this.CloseButton.Size = new System.Drawing.Size(75, 23);
+            this.CloseButton.TabIndex = 2;
+            this.CloseButton.Text = "Close";
+            this.CloseButton.UseVisualStyleBackColor = true;
+            // 
+            // changelogBox
+            // 
+            this.changelogBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.changelogBox.Location = new System.Drawing.Point(12, 12);
+            this.changelogBox.Name = "changelogBox";
+            this.changelogBox.ReadOnly = true;
+            this.changelogBox.Size = new System.Drawing.Size(400, 115);
+            this.changelogBox.TabIndex = 4;
+            this.changelogBox.Text = "";
+            // 
+            // UpdateCheckerNewVersionForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(424, 168);
+            this.Controls.Add(this.changelogBox);
+            this.Controls.Add(this.CloseButton);
+            this.Controls.Add(this.forgetUpdate);
+            this.Controls.Add(this.downloadButton);
+            this.Name = "UpdateCheckerNewVersionForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.Text = "New Version Available";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button downloadButton;
+        private System.Windows.Forms.Button forgetUpdate;
+        private System.Windows.Forms.Button CloseButton;
+        private System.Windows.Forms.RichTextBox changelogBox;
+    }
+}

--- a/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.Designer.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.Designer.cs
@@ -1,4 +1,20 @@
-﻿namespace OpenSubtitles.PlayerExtensions
+﻿// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+namespace Mpdn.PlayerExtensions.GitHub
 {
     partial class UpdateCheckerNewVersionForm
     {

--- a/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
@@ -1,9 +1,24 @@
-﻿using System;
+﻿// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+using System;
 using System.Diagnostics;
 using System.Windows.Forms;
-using Mpdn.PlayerExtensions.GitHub;
 
-namespace OpenSubtitles.PlayerExtensions
+namespace Mpdn.PlayerExtensions.GitHub
 {
     public partial class UpdateCheckerNewVersionForm : Form
     {

--- a/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows.Forms;
+using Mpdn.PlayerExtensions.GitHub;
+
+namespace OpenSubtitles.PlayerExtensions
+{
+    public partial class UpdateCheckerNewVersionForm : Form
+    {
+        private readonly UpdateCheckerSettings m_settings;
+        public UpdateCheckerNewVersionForm(UpdateChecker.Version version, UpdateCheckerSettings settings)
+        {
+            InitializeComponent();
+            m_settings = settings;
+            Text += ": " + version;
+            changelogBox.Text = version.Changelog;
+            CancelButton = CloseButton;
+        }
+
+        private void forgetUpdate_Click(object sender, EventArgs e)
+        {
+            m_settings.ForgetVersion = true;
+            Close();
+        }
+
+        private void downloadButton_Click(object sender, EventArgs e)
+        {
+            Process.Start(UpdateChecker.WebsiteUrl);
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
Check for new version Async at launch of the player
Let the user decide if they want to download it or forget the new version
Can be disabled in the configuration or by keyboard shortcut