### PR TITLE
Move Filters to RenderChain namespace

### DIFF
--- a/Examples/RenderScripts/Example.Basic.cs
+++ b/Examples/RenderScripts/Example.Basic.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 // 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.Resizer;
 

--- a/Examples/RenderScripts/Example.CustomTextures.cs
+++ b/Examples/RenderScripts/Example.CustomTextures.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Drawing;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 using SharpDX;

--- a/Examples/RenderScripts/Example.DirectCompute.cs
+++ b/Examples/RenderScripts/Example.DirectCompute.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 // 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.Resizer;
 using Mpdn.RenderScript;

--- a/Examples/RenderScripts/Example.FrameRateHalver.cs
+++ b/Examples/RenderScripts/Example.FrameRateHalver.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 // 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 

--- a/Examples/RenderScripts/Example.Lut3D.cs
+++ b/Examples/RenderScripts/Example.Lut3D.cs
@@ -16,7 +16,6 @@
 // 
 using System;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 

--- a/Examples/RenderScripts/Example.OpenCl.cs
+++ b/Examples/RenderScripts/Example.OpenCl.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 // 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.Resizer;
 using Mpdn.RenderScript;

--- a/Examples/RenderScripts/Example.Sm5.cs
+++ b/Examples/RenderScripts/Example.Sm5.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.Resizer;
 using Mpdn.RenderScript;

--- a/Extensions/Framework/RenderChain/Filter.Shaders.cs
+++ b/Extensions/Framework/RenderChain/Filter.Shaders.cs
@@ -20,10 +20,10 @@ using System.Linq;
 using Mpdn.OpenCl;
 using Mpdn.RenderScript;
 using SharpDX;
-using TransformFunc = System.Func<Mpdn.Extensions.Framework.Filter.TextureSize, Mpdn.Extensions.Framework.Filter.TextureSize>;
-using IBaseFilter = Mpdn.Extensions.Framework.Filter.IFilter<Mpdn.IBaseTexture>;
+using TransformFunc = System.Func<Mpdn.Extensions.Framework.RenderChain.TextureSize, Mpdn.Extensions.Framework.RenderChain.TextureSize>;
+using IBaseFilter = Mpdn.Extensions.Framework.RenderChain.IFilter<Mpdn.IBaseTexture>;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public class ShaderFilterSettings<T>
     {

--- a/Extensions/Framework/RenderChain/Filter.Sources.cs
+++ b/Extensions/Framework/RenderChain/Filter.Sources.cs
@@ -15,9 +15,9 @@
 // License along with this library.
 
 using Mpdn.RenderScript;
-using IBaseFilter = Mpdn.Extensions.Framework.Filter.IFilter<Mpdn.IBaseTexture>;
+using IBaseFilter = Mpdn.Extensions.Framework.RenderChain.IFilter<Mpdn.IBaseTexture>;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public abstract class BaseSourceFilter<TTexture> : IFilter<TTexture>
         where TTexture : class, IBaseTexture

--- a/Extensions/Framework/RenderChain/Filter.Text.cs
+++ b/Extensions/Framework/RenderChain/Filter.Text.cs
@@ -24,7 +24,7 @@ using SharpDX;
 using Color = System.Drawing.Color;
 using Rectangle = System.Drawing.Rectangle;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public class TextFilter : BaseSourceFilter<ITexture2D>, IFilter, IDisposable
     {

--- a/Extensions/Framework/RenderChain/Filter.Utilities.cs
+++ b/Extensions/Framework/RenderChain/Filter.Utilities.cs
@@ -19,9 +19,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Mpdn.RenderScript;
 using SharpDX;
-using IBaseFilter = Mpdn.Extensions.Framework.Filter.IFilter<Mpdn.IBaseTexture>;
+using IBaseFilter = Mpdn.Extensions.Framework.RenderChain.IFilter<Mpdn.IBaseTexture>;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public abstract class BasicFilter : Filter
     {

--- a/Extensions/Framework/RenderChain/Filter.cs
+++ b/Extensions/Framework/RenderChain/Filter.cs
@@ -18,10 +18,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mpdn.RenderScript;
-using TransformFunc = System.Func<Mpdn.Extensions.Framework.Filter.TextureSize, Mpdn.Extensions.Framework.Filter.TextureSize>;
-using IBaseFilter = Mpdn.Extensions.Framework.Filter.IFilter<Mpdn.IBaseTexture>;
+using TransformFunc = System.Func<Mpdn.Extensions.Framework.RenderChain.TextureSize, Mpdn.Extensions.Framework.RenderChain.TextureSize>;
+using IBaseFilter = Mpdn.Extensions.Framework.RenderChain.IFilter<Mpdn.IBaseTexture>;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public interface IFilter<out TTexture>
         where TTexture : class, IBaseTexture

--- a/Extensions/Framework/RenderChain/Presets.cs
+++ b/Extensions/Framework/RenderChain/Presets.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using Mpdn.Extensions.Framework.Filter;
 using YAXLib;
 
 namespace Mpdn.Extensions.Framework.RenderChain

--- a/Extensions/Framework/RenderChain/RenderChain.cs
+++ b/Extensions/Framework/RenderChain/RenderChain.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.OpenCl;
 using Mpdn.RenderScript;
 using TransformFunc = System.Func<System.Drawing.Size, System.Drawing.Size>;

--- a/Extensions/Framework/RenderChain/RenderChainScript.cs
+++ b/Extensions/Framework/RenderChain/RenderChainScript.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Drawing;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.RenderScript;
 
 namespace Mpdn.Extensions.Framework.RenderChain

--- a/Extensions/Framework/RenderChain/Textures.cs
+++ b/Extensions/Framework/RenderChain/Textures.cs
@@ -20,7 +20,7 @@ using System.Drawing;
 using Mpdn.RenderScript;
 using SharpDX;
 
-namespace Mpdn.Extensions.Framework.Filter
+namespace Mpdn.Extensions.Framework.RenderChain
 {
     public struct TextureSize
     {

--- a/Extensions/Framework/Scripting/ScriptEngine.cs
+++ b/Extensions/Framework/Scripting/ScriptEngine.cs
@@ -23,7 +23,7 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.Windows;
-using Mpdn.Extensions.Framework.Filter;
+using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.Framework.Scripting.ScriptEngineUtilities;
 using Mpdn.RenderScript;
 using ClearScriptEngine = Microsoft.ClearScript.ScriptEngine;

--- a/Extensions/Framework/Scripting/ScriptEngineUtilities.cs
+++ b/Extensions/Framework/Scripting/ScriptEngineUtilities.cs
@@ -21,7 +21,6 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 using SharpDX;

--- a/Extensions/RenderScripts/Custom.MyRenderScript.cs
+++ b/Extensions/RenderScripts/Custom.MyRenderScript.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.ImageProcessor;
 using Mpdn.Extensions.RenderScripts.Mpdn.Resizer;

--- a/Extensions/RenderScripts/Mpdn.Conditional.cs
+++ b/Extensions/RenderScripts/Mpdn.Conditional.cs
@@ -16,7 +16,6 @@
 // 
 using System;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.Framework.Scripting;
 

--- a/Extensions/RenderScripts/Mpdn.ImageProcessor.cs
+++ b/Extensions/RenderScripts/Mpdn.ImageProcessor.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Linq;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 
 namespace Mpdn.Extensions.RenderScripts

--- a/Extensions/RenderScripts/Mpdn.Lut3D.cs
+++ b/Extensions/RenderScripts/Mpdn.Lut3D.cs
@@ -18,7 +18,6 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.OpenCl;
 using Mpdn.RenderScript;

--- a/Extensions/RenderScripts/Mpdn.Presets.cs
+++ b/Extensions/RenderScripts/Mpdn.Presets.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.PlayerExtensions;
 using YAXLib;

--- a/Extensions/RenderScripts/Mpdn.Resizer.cs
+++ b/Extensions/RenderScripts/Mpdn.Resizer.cs
@@ -17,7 +17,6 @@
 using System;
 using System.ComponentModel;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 

--- a/Extensions/RenderScripts/Mpdn.ScriptedRenderChain.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptedRenderChain.cs
@@ -17,7 +17,6 @@
 using System;
 using System.IO;
 using Mpdn.Extensions.Framework;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.Framework.Scripting;
 

--- a/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.ComponentModel;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 using SharpDX;

--- a/Extensions/RenderScripts/Shiandow.Deband.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 

--- a/Extensions/RenderScripts/Shiandow.Nedi.NediScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nedi.NediScaler.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 using SharpDX;

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Filters.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Filters.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using Mpdn.Extensions.Framework.Filter;
+using Mpdn.Extensions.Framework.RenderChain;
 
 namespace Mpdn.Extensions.RenderScripts
 {

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Shiandow.NNedi3.Filters;
 using Mpdn.RenderScript;

--- a/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
@@ -15,7 +15,6 @@
 // License along with this library.
 
 using System;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.RenderScript;
 using Mpdn.RenderScript.Scaler;

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using Mpdn.Extensions.Framework.Filter;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.RenderScripts.Mpdn.OclNNedi3;
 using Mpdn.Extensions.RenderScripts.Mpdn.Presets;


### PR DESCRIPTION
RenderChains require Filters to be of any use.