### PR TITLE
Some Cleanup of the Uninstall process

### DIFF
--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -272,22 +272,10 @@ FunctionEnd
 
 Section "Uninstall"
 
-    ReadRegStr $R0 HKLM "SOFTWARE\${MPDN_REGNAME}_x86" ""
-    StrCpy $mpdn32_root "$R0"
-    ReadRegStr $R0 HKLM "SOFTWARE\${MPDN_REGNAME}_x64" ""
-    StrCpy $mpdn64_root "$R0"
-
     ${GetParent} $INSTDIR $R0
-    
-    ${If} "$R0" == "$mpdn32_root"
-        StrCpy $mpdn_root $mpdn32_root
-        Call un.includeUninstall
-    ${EndIf}
-    ${If} "$R0" == "$mpdn64_root"
-        StrCpy $mpdn_root $mpdn64_root
-        Call un.includeUninstall
-    ${EndIf}
-        Delete "$INSTDIR\Uninstall.exe"
+    StrCpy $mpdn_root "$R0"
+    Call un.includeUninstall
+    Delete "$INSTDIR\Uninstall.exe"
 SectionEnd
 
 ;--------------------------------

--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -42,6 +42,7 @@ SetCompressor lzma
 
 Var /GLOBAL mpdn32_root
 Var /GLOBAL mpdn64_root
+Var /GLOBAL mpdn_root
 Var /GLOBAL uninstallerPresent
 Var /Global doCleanInstall
 
@@ -264,6 +265,10 @@ FunctionEnd
 
 ;--------------------------------
 ;Uninstaller Sections
+Function un.includeUninstall
+    DetailPrint "Remove un-modified files"
+    !include UnInstallLog.log
+FunctionEnd
 
 Section "Uninstall"
 
@@ -275,14 +280,14 @@ Section "Uninstall"
     ${GetParent} $INSTDIR $R0
     
     ${If} "$R0" == "$mpdn32_root"
-        !include UnInstallLog32.log
-        Delete "$INSTDIR\Uninstall.exe"
+        StrCpy $mpdn_root $mpdn32_root
+        Call un.includeUninstall
     ${EndIf}
     ${If} "$R0" == "$mpdn64_root"
-        !include UnInstallLog64.log    
-        Delete "$INSTDIR\Uninstall.exe"
+        StrCpy $mpdn_root $mpdn64_root
+        Call un.includeUninstall
     ${EndIf}
-
+        Delete "$INSTDIR\Uninstall.exe"
 SectionEnd
 
 ;--------------------------------

--- a/Installer/Make-Installer.bat
+++ b/Installer/Make-Installer.bat
@@ -26,9 +26,11 @@ if not "%ERRORLEVEL%"=="0" echo error: extraction failed & goto Quit
 REM Generator of Uninstaller
 %makensis% /V1 unList.nsi
 
+if exist UnInstallLog.log (
+    del UnInstallLog.log
+)
 REM The Installer
-unList.exe /DATE=1  /INSTDIR=TEMP\Extensions\  /LOG=UnInstallLog64.log  /PREFIX="	"  /UNDIR_VAR="$mpdn64_root\Extensions"  /MB=0
-unList.exe /DATE=1  /INSTDIR=TEMP\Extensions\  /LOG=UnInstallLog32.log  /PREFIX="	"  /UNDIR_VAR="$mpdn32_root\Extensions"  /MB=0
+unList.exe /DATE=1  /INSTDIR=TEMP\Extensions\  /LOG=UnInstallLog.log  /PREFIX="	"  /UNDIR_VAR="$mpdn_root\Extensions"  /MB=0
 %makensis% "/DPROJECT_NAME=MPDN-Extensions" "/DMPDN_REGNAME=MediaPlayerDotNet" /V1 Installer.nsi
 if not "%ERRORLEVEL%"=="0" echo error: makensis failed & goto Quit
 


### PR DESCRIPTION
Minor changes to reduce the size of the uninstaller (and installer) by removing the use of 2 set of instruction for X64 and X86.

The files are the same for both version, using only one set of instruction with a Directory variable set before processing the uninstall instructions.