### PR TITLE
Add Extension version to the registry

### DIFF
--- a/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.PlayerExtension.cs
@@ -18,9 +18,11 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Microsoft.Win32;
 using Mpdn.Extensions.Framework;
 
 namespace Mpdn.Extensions.PlayerExtensions
@@ -126,7 +128,12 @@ namespace Mpdn.Extensions.PlayerExtensions
 
         private void SetHeaders()
         {
-            m_WebClient.Headers.Add("User-Agent", string.Format("MPDN/{0} (+http://mpdn.zachsaw.com/)", Application.ProductVersion));
+            var version = Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\MediaPlayerDotNet_Extensions", "Version", null);
+            if (version == null)
+            {
+                version = "0.0.0.0";
+            }
+            m_WebClient.Headers.Add("User-Agent", string.Format("Mozilla/5.0 (compatible; Windows NT {0}; MPDN/{1}; MPDN_Extensions/{2}; +http://mpdn.zachsaw.com/)", Environment.OSVersion.Version, Application.ProductVersion, version));
         }
 
         private void DownloadStringCompleted(object sender, DownloadStringCompletedEventArgs e)

--- a/Installer/Installer.nsi
+++ b/Installer/Installer.nsi
@@ -169,7 +169,6 @@ SectionEnd
 
 Section /o "Extensions for MPDN x86" SecMPDNExtensions32
     !insertmacro InstallExtensions "$mpdn32_root"
-
 SectionEnd
 
 Section /o "Extensions for MPDN x64" SecMPDNExtensions64
@@ -184,6 +183,7 @@ Section -post
     ${IfNot} $mpdn32_root == ""
         ${registerExtension} "$mpdn32_root\MediaPlayerDotNet.exe" ".mpl" "MPDN Playlist File"
     ${EndIf}
+    WriteRegStr HKLM "SOFTWARE\${MPDN_REGNAME}_Extensions\" "Version" "${VERSION}"
     
 SectionEnd
 
@@ -275,6 +275,7 @@ Section "Uninstall"
     ${GetParent} $INSTDIR $R0
     StrCpy $mpdn_root "$R0"
     Call un.includeUninstall
+    DeleteRegKey HKLM "SOFTWARE\${MPDN_REGNAME}_Extensions\"
     Delete "$INSTDIR\Uninstall.exe"
 SectionEnd
 

--- a/Installer/Make-Installer.bat
+++ b/Installer/Make-Installer.bat
@@ -19,6 +19,12 @@ if not exist %makensis% (
 
 echo Making installer...
 
+git describe --abbrev=0 --tags > latestTag.txt
+for /f "delims=" %%i in ('git rev-list HEAD --count') do set commitCount=%%i
+set /p latestTag=<latestTag.txt
+del latestTag.txt
+set releaseVersion=%latestTag%.%commitCount%
+
 rmdir /s /q Temp 1>nul 2>nul
 %zipper% x "..\Release\Mpdn.Extensions.zip" -oTemp *.* -r 1>nul 2>nul
 if not "%ERRORLEVEL%"=="0" echo error: extraction failed & goto Quit
@@ -31,7 +37,7 @@ if exist UnInstallLog.log (
 )
 REM The Installer
 unList.exe /DATE=1  /INSTDIR=TEMP\Extensions\  /LOG=UnInstallLog.log  /PREFIX="	"  /UNDIR_VAR="$mpdn_root\Extensions"  /MB=0
-%makensis% "/DPROJECT_NAME=MPDN-Extensions" "/DMPDN_REGNAME=MediaPlayerDotNet" /V1 Installer.nsi
+%makensis% "/DPROJECT_NAME=MPDN-Extensions" "/DMPDN_REGNAME=MediaPlayerDotNet" "/DVERSION=%releaseVersion%" /V1 Installer.nsi
 if not "%ERRORLEVEL%"=="0" echo error: makensis failed & goto Quit
 
 rmdir /s /q Temp 1>nul 2>nul


### PR DESCRIPTION
Use the version in the UpdateChecker for the User-Agent.

To be used later on to check the version of the Extension for an "Extension" of the UpdateChecker.
I couldn't get the version of the Extensions otherwise since the Assembly generated by MPDN was always giving a version of 0.0.0.0.