### PR TITLE
Multiple refactoring to VersionHelpers. FIX deserialize bug with ExtensionVersion.

### DIFF
--- a/Extensions/Framework/Config/ConfigProviders.cs
+++ b/Extensions/Framework/Config/ConfigProviders.cs
@@ -16,6 +16,7 @@
 // 
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using YAXLib;
 
@@ -69,6 +70,8 @@ namespace Mpdn.Extensions.Framework.Config
             {
                 loadException = ex;
                 Configuration = new T();
+                Trace.WriteLine(string.Format("Failed to deserialize: {0}", m_FileName));
+                Trace.Write(ex);
             }
             return false;
         }

--- a/Extensions/Framework/Exceptions/InternetConnectivityException.cs
+++ b/Extensions/Framework/Exceptions/InternetConnectivityException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Mpdn.Extensions.Framework.Exceptions
+{
+    public class InternetConnectivityException : Exception
+    {
+        public InternetConnectivityException()
+        {
+        }
+
+        public InternetConnectivityException(string message)
+            : base(message)
+        {
+        }
+
+        public InternetConnectivityException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Extensions/Framework/Helpers.cs
+++ b/Extensions/Framework/Helpers.cs
@@ -343,6 +343,10 @@ namespace Mpdn.Extensions.Framework
 
         public class ExtensionVersion : Version
         {
+            public ExtensionVersion()
+            {
+            }
+
             public ExtensionVersion(string version)
                 : base(version)
             {

--- a/Extensions/PlayerExtensions/OpenSubtitles.Downloader.cs
+++ b/Extensions/PlayerExtensions/OpenSubtitles.Downloader.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Text;
+using Mpdn.Extensions.Framework.Exceptions;
 
 namespace Mpdn.Extensions.PlayerExtensions
 {
@@ -76,9 +77,9 @@ namespace Mpdn.Extensions.PlayerExtensions
                     return client.DownloadString(url);
                 }
             }
-            catch (Exception)
+            catch (Exception exception)
             {                
-                throw new InternetConnectivityException();
+                throw new InternetConnectivityException(string.Format("Url: {0}", url), exception);
             }
   
         }
@@ -109,11 +110,11 @@ namespace Mpdn.Extensions.PlayerExtensions
                 throw new EmptyResponseException();
             }
 
-            return parseSubtitlesResponse(subs);
+            return ParseSubtitlesResponse(subs);
 
         }
 
-        private List<Subtitle> parseSubtitlesResponse(string subs)
+        private List<Subtitle> ParseSubtitlesResponse(string subs)
         {
             var subList = new List<Subtitle>();
             var subtitle = new Subtitle(this);
@@ -244,11 +245,6 @@ namespace Mpdn.Extensions.PlayerExtensions
     }
 
     public class EmptyResponseException : Exception
-    {
-
-    }
-
-    public class InternetConnectivityException : Exception
     {
 
     }

--- a/Extensions/PlayerExtensions/OpenSubtitles.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/OpenSubtitles.PlayerExtension.cs
@@ -18,10 +18,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Windows.Forms;
 using Mpdn.Extensions.Framework;
 using Mpdn.Extensions.Framework.Controls;
 using System.IO;
+using Mpdn.Extensions.Framework.Exceptions;
 
 namespace Mpdn.Extensions.PlayerExtensions
 {

--- a/Extensions/PlayerExtensions/OpenSubtitles.Subtitles.Form.cs
+++ b/Extensions/PlayerExtensions/OpenSubtitles.Subtitles.Form.cs
@@ -16,9 +16,11 @@
 // 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using Mpdn.Extensions.Framework.Controls;
+using Mpdn.Extensions.Framework.Exceptions;
 
 namespace Mpdn.Extensions.PlayerExtensions
 {
@@ -87,9 +89,10 @@ namespace Mpdn.Extensions.PlayerExtensions
                 }
                 Close();
             }
-            catch (InternetConnectivityException)
+            catch (InternetConnectivityException exception)
             {
                 MessageBox.Show(this, "MPDN was unable to access OpenSubtitles.org");
+                Trace.WriteLine(string.Format("InternetConnectivityProblem: {0}", exception.Message));
             }
             catch (Exception)
             {

--- a/Extensions/PlayerExtensions/UpdateChecker.ExtensionAvailable.Form.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.ExtensionAvailable.Form.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows.Forms;
+using Mpdn.Extensions.Framework;
 
 namespace Mpdn.Extensions.PlayerExtensions
 {
@@ -26,9 +27,9 @@ namespace Mpdn.Extensions.PlayerExtensions
     {
         private readonly UpdateCheckerSettings _settings;
         private string _chosenDownload = null;
-        private readonly List<ExtensionUpdateChecker.GitHubVersion.GitHubAsset> _files;
+        private readonly List<VersionHelpers.GitHubVersion.GitHubAsset> _files;
 
-        public UpdateCheckerNewExtensionForm(ExtensionUpdateChecker.ExtensionVersion version, UpdateCheckerSettings settings)
+        public UpdateCheckerNewExtensionForm(VersionHelpers.ExtensionVersion version, UpdateCheckerSettings settings)
         {
             InitializeComponent();
             Icon = PlayerControl.ApplicationIcon;

--- a/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker.UpdateAvailable.Form.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Windows.Forms;
+using Mpdn.Extensions.Framework;
 
 namespace Mpdn.Extensions.PlayerExtensions
 {
@@ -24,7 +25,7 @@ namespace Mpdn.Extensions.PlayerExtensions
     {
         private readonly UpdateCheckerSettings m_settings;
 
-        public UpdateCheckerNewVersionForm(UpdateChecker.Version version, UpdateCheckerSettings settings)
+        public UpdateCheckerNewVersionForm(VersionHelpers.Version version, UpdateCheckerSettings settings)
         {
             InitializeComponent();
             m_settings = settings;

--- a/Mpdn.Extensions.csproj
+++ b/Mpdn.Extensions.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Extensions\Framework\Controls\ScriptEditorDialog.Designer.cs">
       <DependentUpon>ScriptEditorDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Extensions\Framework\Exceptions\InternetConnectivityException.cs" />
     <Compile Include="Extensions\Framework\Exceptions\MpdnScriptEngineException.cs" />
     <Compile Include="Extensions\Framework\Exceptions\RenderScriptException.cs" />
     <Compile Include="Extensions\Framework\Helpers.cs" />


### PR DESCRIPTION
Some refactoring to move the Version in the framework and have a single place that manage it. 

I discover that the YAXLib was configured to failed silently, I make it trace now when it can't deserialize a configuration, it helped me to correct the bug in the ExtensionVersion (missing default constructor).