### PR TITLE
Change Error Handling, Improve Debanding, Optimize SuperRes

### DIFF
--- a/Extensions/Framework/Helpers.cs
+++ b/Extensions/Framework/Helpers.cs
@@ -239,6 +239,24 @@ namespace Mpdn.Extensions.Framework
                     throw new ArgumentOutOfRangeException("scalerTaps");
             }
         }
+        
+        public static float[] GetYuvConsts(this YuvColorimetric colorimetric) 
+        {
+            switch (colorimetric)
+            {
+                case YuvColorimetric.FullRangePc601:
+                case YuvColorimetric.ItuBt601:
+                    return new[] {0.114f, 0.299f};
+                case YuvColorimetric.FullRangePc709:
+                case YuvColorimetric.ItuBt709:
+                    return new[] {0.0722f, 0.2126f};
+                case YuvColorimetric.FullRangePc2020:
+                case YuvColorimetric.ItuBt2020:
+                    return new[] {0.0593f, 0.2627f};
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 
     public static class StringHelpers

--- a/Extensions/Framework/RenderChain/Presets.cs
+++ b/Extensions/Framework/RenderChain/Presets.cs
@@ -101,7 +101,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
         public override IFilter CreateFilter(IFilter input)
         {
-            return Script != null ? Chain.CreateSafeFilter(input) : input;
+            return Script != null ? input + Chain : input;
         }
 
         public override void Initialize()

--- a/Extensions/Framework/RenderChain/RenderChain.cs
+++ b/Extensions/Framework/RenderChain/RenderChain.cs
@@ -16,7 +16,6 @@
 // 
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using Mpdn.OpenCl;
 using Mpdn.RenderScript;
@@ -36,7 +35,6 @@ namespace Mpdn.Extensions.Framework.RenderChain
         #region Operators
 
         public static RenderChain Identity = new StaticChain(x => x);
-        private TextFilter m_TextFilter;
 
         public static implicit operator Func<IFilter, IFilter>(RenderChain map)
         {
@@ -166,51 +164,10 @@ namespace Mpdn.Extensions.Framework.RenderChain
         /// </summary>
         public virtual void Reset()
         {
-            DisposeHelper.Dispose(ref m_TextFilter);
         }
 
         #endregion
 
-        #region Error Handling
-
-        public IFilter CreateSafeFilter(IFilter input)
-        {
-            DisposeHelper.Dispose(ref m_TextFilter);
-            try
-            {
-                return CreateFilter(input);
-            }
-            catch (Exception ex)
-            {
-                return DisplayError(ex);
-            }
-        }
-
-        private IFilter DisplayError(Exception e)
-        {
-            var message = ErrorMessage(e);
-            Trace.WriteLine(message);
-            return m_TextFilter = new TextFilter(message);
-        }
-
-        protected static Exception InnerMostException(Exception e)
-        {
-            while (e.InnerException != null)
-            {
-                e = e.InnerException;
-            }
-
-            return e;
-        }
-
-        private string ErrorMessage(Exception e)
-        {
-            var ex = InnerMostException(e);
-            return string.Format("Error in {0}:\r\n\r\n{1}\r\n\r\n~\r\nStack Trace:\r\n{2}",
-                    GetType().Name, ex.Message, ex.StackTrace);
-        }
-
-        #endregion
     }
 
     public class StaticChain : RenderChain

--- a/Extensions/RenderScripts/Common/ColourProcessing.hlsl
+++ b/Extensions/RenderScripts/Common/ColourProcessing.hlsl
@@ -15,9 +15,15 @@
 // License along with this library.
 // 
 // -- Color space options --
-#define GammaCurve Rec709
-#define gamma 2.2
-#define QuasiLab true
+#ifndef GammaCurve
+    #define GammaCurve Rec709
+#endif
+#ifndef gamma
+    #define gamma 2.2
+#endif
+#ifndef QuasiLab
+    #define QuasiLab true
+#endif
 
 // -- Option values --
 #define None   1

--- a/Extensions/RenderScripts/Deband/Deband.hlsl
+++ b/Extensions/RenderScripts/Deband/Deband.hlsl
@@ -74,10 +74,12 @@ float4 main(float2 tex : TEXCOORD0) : COLOR {
 
 	// Statistical analysis
 	X *= acuity;
-	float SSres = sqr(mul(float4(0.5,-0.5,-0.5,0.5),X).xyz);
-	float SStot = (sqr(X[0].xyz) + sqr(X[1].xyz) + sqr(X[2].xyz) + sqr(X[3].xyz)) - sqr(mul(float4(0.5,0.5,0.5,0.5),X).xyz);
-	float R = 1 - (SSres/SStot);
+	#define sqr(x) ((x)*(x))
+	float3 SSres = sqr(mul(float4(0.5,-0.5,-0.5,0.5),X).xyz);
+	float3 SStot = (sqr(X[0].xyz) + sqr(X[1].xyz) + sqr(X[2].xyz) + sqr(X[3].xyz)) - sqr(mul(float4(0.5,0.5,0.5,0.5),X).xyz);
+	float3 R = 1 - (SSres/SStot);
 	float3 p = saturate(abs(c0 - avg)*acuity);
+	SSres = (SSres + saturate(p - 0.5))/2.0; // 5 samples - 3 dof = 2.
 
 	// Merge with high res values
 	float3 str = p*(1-p)*power/(SSres*(1 - power) + p*(1-p)*power);

--- a/Extensions/RenderScripts/Mpdn.ScriptChain.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptChain.cs
@@ -26,7 +26,7 @@ namespace Mpdn.Extensions.RenderScripts
         {
             public override IFilter CreateFilter(IFilter input)
             {
-                return Options.Aggregate(input, (result, chain) => chain.CreateSafeFilter(result));
+                return Options.Aggregate(input, (result, chain) => result + chain);
             }
         }
 

--- a/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
@@ -88,7 +88,7 @@ namespace Mpdn.Extensions.RenderScripts
 
             public override IFilter CreateFilter(IFilter input)
             {
-                return SelectedOption != null ? SelectedOption.CreateSafeFilter(input) : input;
+                return SelectedOption != null ? input + SelectedOption : input;
             }
 
             public override void Initialize()

--- a/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.Designer.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.Designer.cs
@@ -51,14 +51,10 @@ namespace Mpdn.Extensions.RenderScripts
             this.label5 = new System.Windows.Forms.Label();
             this.MaxBitdepthSetter = new System.Windows.Forms.NumericUpDown();
             this.label3 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.ThresholdSetter = new System.Windows.Forms.NumericUpDown();
-            this.label6 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.PowerSetter = new System.Windows.Forms.NumericUpDown();
             this.GrainBox = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.MaxBitdepthSetter)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ThresholdSetter)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.PowerSetter)).BeginInit();
             this.SuspendLayout();
             // 
@@ -67,7 +63,7 @@ namespace Mpdn.Extensions.RenderScripts
             this.ButtonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ButtonOK.Cursor = System.Windows.Forms.Cursors.Default;
             this.ButtonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.ButtonOK.Location = new System.Drawing.Point(79, 114);
+            this.ButtonOK.Location = new System.Drawing.Point(70, 95);
             this.ButtonOK.Name = "ButtonOK";
             this.ButtonOK.Size = new System.Drawing.Size(75, 23);
             this.ButtonOK.TabIndex = 3;
@@ -79,7 +75,7 @@ namespace Mpdn.Extensions.RenderScripts
             this.ButtonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.ButtonCancel.Cursor = System.Windows.Forms.Cursors.Default;
             this.ButtonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.ButtonCancel.Location = new System.Drawing.Point(160, 114);
+            this.ButtonCancel.Location = new System.Drawing.Point(151, 95);
             this.ButtonCancel.Name = "ButtonCancel";
             this.ButtonCancel.Size = new System.Drawing.Size(75, 23);
             this.ButtonCancel.TabIndex = 4;
@@ -127,49 +123,6 @@ namespace Mpdn.Extensions.RenderScripts
             this.label3.TabIndex = 12;
             this.label3.Text = "bits";
             // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(20, 67);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(78, 13);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Margin for error";
-            // 
-            // ThresholdSetter
-            // 
-            this.ThresholdSetter.DecimalPlaces = 2;
-            this.ThresholdSetter.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            131072});
-            this.ThresholdSetter.Location = new System.Drawing.Point(153, 65);
-            this.ThresholdSetter.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            65536});
-            this.ThresholdSetter.Name = "ThresholdSetter";
-            this.ThresholdSetter.Size = new System.Drawing.Size(44, 20);
-            this.ThresholdSetter.TabIndex = 2;
-            this.ThresholdSetter.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.ThresholdSetter.Value = new decimal(new int[] {
-            10,
-            0,
-            0,
-            65536});
-            this.ThresholdSetter.ValueChanged += new System.EventHandler(this.ValueChanged);
-            // 
-            // label6
-            // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(203, 67);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(29, 13);
-            this.label6.TabIndex = 15;
-            this.label6.Text = "bit(s)";
-            // 
             // label4
             // 
             this.label4.AutoSize = true;
@@ -206,7 +159,7 @@ namespace Mpdn.Extensions.RenderScripts
             // GrainBox
             // 
             this.GrainBox.AutoSize = true;
-            this.GrainBox.Location = new System.Drawing.Point(153, 91);
+            this.GrainBox.Location = new System.Drawing.Point(153, 65);
             this.GrainBox.Name = "GrainBox";
             this.GrainBox.Size = new System.Drawing.Size(71, 17);
             this.GrainBox.TabIndex = 18;
@@ -219,17 +172,14 @@ namespace Mpdn.Extensions.RenderScripts
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.ButtonCancel;
-            this.ClientSize = new System.Drawing.Size(247, 149);
+            this.ClientSize = new System.Drawing.Size(238, 130);
             this.Controls.Add(this.GrainBox);
             this.Controls.Add(this.PowerSetter);
             this.Controls.Add(this.label4);
             this.Controls.Add(this.label3);
-            this.Controls.Add(this.label6);
             this.Controls.Add(this.label5);
-            this.Controls.Add(this.ThresholdSetter);
             this.Controls.Add(this.MaxBitdepthSetter);
             this.Controls.Add(this.ButtonCancel);
-            this.Controls.Add(this.label2);
             this.Controls.Add(this.ButtonOK);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
@@ -240,7 +190,6 @@ namespace Mpdn.Extensions.RenderScripts
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Deband Settings";
             ((System.ComponentModel.ISupportInitialize)(this.MaxBitdepthSetter)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.ThresholdSetter)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.PowerSetter)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -254,9 +203,6 @@ namespace Mpdn.Extensions.RenderScripts
             private System.Windows.Forms.Label label5;
             private System.Windows.Forms.NumericUpDown MaxBitdepthSetter;
             private System.Windows.Forms.Label label3;
-            private System.Windows.Forms.Label label2;
-            private System.Windows.Forms.NumericUpDown ThresholdSetter;
-            private System.Windows.Forms.Label label6;
             private System.Windows.Forms.Label label4;
             private System.Windows.Forms.NumericUpDown PowerSetter;
             private System.Windows.Forms.CheckBox GrainBox;

--- a/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.cs
@@ -31,7 +31,6 @@ namespace Mpdn.Extensions.RenderScripts
             protected override void LoadSettings()
             {
                 MaxBitdepthSetter.Value = (Decimal)Settings.maxbitdepth;
-                ThresholdSetter.Value = (Decimal)Settings.margin;
                 PowerSetter.Value = (Decimal)Settings.power;
                 GrainBox.Checked = Settings.grain;
 
@@ -41,7 +40,6 @@ namespace Mpdn.Extensions.RenderScripts
             protected override void SaveSettings()
             {
                 Settings.maxbitdepth = (int)MaxBitdepthSetter.Value;
-                Settings.margin = (float)ThresholdSetter.Value;
                 Settings.power = (float)PowerSetter.Value;
                 Settings.grain = GrainBox.Checked;
             }

--- a/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
@@ -72,29 +72,9 @@ namespace Mpdn.Extensions.RenderScripts
                 var uInput = new USourceFilter();
                 var vInput = new VSourceFilter();
 
-                float[] yuvConsts;
-                int bitdepth = (uInput.OutputFormat == TextureFormat.Unorm8) ? 8 : 10;
-                
-                float range = (1 << bitdepth) - 1;
-                bool limited = Renderer.Colorimetric.IsLimitedRange();
-
-                switch (Renderer.Colorimetric)
-                {
-                    case YuvColorimetric.FullRangePc601:
-                    case YuvColorimetric.ItuBt601:
-                        yuvConsts = new[] {0.114f, 0.299f};
-                        break;
-                    case YuvColorimetric.FullRangePc709:
-                    case YuvColorimetric.ItuBt709:
-                        yuvConsts = new[] {0.0722f, 0.2126f};
-                        break;
-                    case YuvColorimetric.FullRangePc2020:
-                    case YuvColorimetric.ItuBt2020:
-                        yuvConsts = new[] {0.0593f, 0.2627f};
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
+                float[] yuvConsts = Renderer.Colorimetric.GetYuvConsts();
+                int bitdepth = Renderer.InputFormat.GetBitDepth();        
+                bool limited = Renderer.Colorimetric.IsLimitedRange();                
 
                 // Skip if downscaling
                 if (targetSize.Width <= chromaSize.Width && targetSize.Height <= chromaSize.Height)
@@ -109,7 +89,7 @@ namespace Mpdn.Extensions.RenderScripts
                 if (IsIntegral(Softness))
                     superResMacros += String.Format("softness = {0};", Softness);
 
-                string diffMacros = string.Format("LimitedRange = {0}; range = {1}", limited ? 1 : 0, range);
+                string diffMacros = string.Format("LimitedRange = {0}; range = {1}", limited ? 1 : 0, (1 << bitdepth) - 1);
 
                 var CopyLuma = CompileShader("CopyLuma.hlsl");
                 var CopyChroma = CompileShader("CopyChroma.hlsl");

--- a/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
@@ -143,7 +143,8 @@ namespace Mpdn.Extensions.RenderScripts
                     IFilter diff, linear;
 
                     // Compare to chroma
-                    linear = new ShaderFilter(GammaToLinear, hiRes.ConvertToRgb());
+                    var rgb = new RgbFilter(hiRes, limitChroma: false);
+                    linear = new ShaderFilter(GammaToLinear, rgb);
                     linear = new ResizeFilter(linear, chromaSize, adjointOffset, upscaler, downscaler);
                     diff = new ShaderFilter(Diff, linear, uInput, vInput);
 

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -80,7 +80,7 @@ namespace Mpdn.Extensions.RenderScripts
                 SelectedIndex = 0;
 
                 m_Upscaler = new Jinc(ScalerTaps.Four, false); // Deprecated
-                m_Downscaler = HQdownscaling ? (IScaler) new Bicubic(0.66f, false) : new Bilinear();              
+                m_Downscaler = HQdownscaling ? (IScaler) new Bicubic(0.66f, false) : new Bilinear();
             }
 
             public override IFilter CreateFilter(IFilter input)
@@ -110,13 +110,6 @@ namespace Mpdn.Extensions.RenderScripts
                 // Compile Shaders
                 var Diff = CompileShader("Diff.hlsl")
                     .Configure( format: TextureFormat.Float16 );
-
-                // Compile Shaders
-                var UpdateDiff = CompileShader("UpdateDiff.hlsl")
-                    .Configure(format: TextureFormat.Float16);
-
-                /*var Diff = CompileShader("BilateralDS.hlsl")
-                    .Configure(format: TextureFormat.Float16, sizeIndex: 1);*/
 
                 var SuperRes = CompileShader("SuperResEx.hlsl", macroDefinitions: macroDefinitions)
                     .Configure(

--- a/Extensions/RenderScripts/SuperRes/Diff.hlsl
+++ b/Extensions/RenderScripts/SuperRes/Diff.hlsl
@@ -23,8 +23,7 @@ float2 p1 :  register(c1);
 #define width  (p0[0])
 #define height (p0[1])
 
-#define px (p1[0])
-#define py (p1[1])
+#define dxdy (p1.xy)
 
 #include "../Common/ColourProcessing.hlsl"
 
@@ -33,7 +32,8 @@ float4 main(float2 tex : TEXCOORD0) : COLOR {
     float4 c0 = tex2D(s0, tex);
     float4 c1 = tex2D(s1, tex);
 
-    c0.xyz = RGBtoLab(c0.rgb);
+	c0.xyz = Gamma(c0.rgb);
+    float3 diff = c0.xyz - c1.xyz;
 
-    return float4(c0.xyz - c1.xyz, c0.y);
+    return float4(diff, Luma(c0));
 }

--- a/Extensions/RenderScripts/SuperRes/SuperChromaRes/SuperResEx.hlsl
+++ b/Extensions/RenderScripts/SuperRes/SuperChromaRes/SuperResEx.hlsl
@@ -25,7 +25,7 @@
 // -- Edge detection options -- 
 #define acuity 6.0
 #define radius 0.66
-#define power 3.0
+#define power 1.0
 
 // -- Misc --
 sampler s0 	  : register(s0);

--- a/Extensions/RenderScripts/SuperRes/SuperResEx.hlsl
+++ b/Extensions/RenderScripts/SuperRes/SuperResEx.hlsl
@@ -69,7 +69,7 @@ float4 main(float2 tex : TEXCOORD0) : COLOR{
     pos -= offset;
 
     // Calculate faithfulness force
-    float totalW = 0;
+    float weightSum = 0;
     float3 diff = 0;
 
     [unroll] for (int X = -1; X <= 1; X++)
@@ -77,12 +77,12 @@ float4 main(float2 tex : TEXCOORD0) : COLOR{
     {
 		float dI2 = sqr(acuity*(Luma(c0) - GetY(X,Y)));
         float dXY2 = sqr(float2(X,Y) - offset);
-        float w = exp(-dXY2/(2*radius*radius))*pow(1 + dI2/power, - power);
+        float weight = exp(-dXY2/(2*radius*radius))*pow(1 + dI2/power, - power);
 
-        diff += w*Diff(X,Y);
-        totalW += w;
+        diff += weight*Diff(X,Y);
+        weightSum += weight;
     }
-    diff /= totalW;
+    diff /= weightSum;
     c0.xyz -= strength * diff;
 
     // Convert back to linear light;


### PR DESCRIPTION
The error handling is now done by the RenderChainScript. This prevents renderscripts like SuperRes from making the error message unreadable. Moving the responsibility to RenderChainScript also means that RenderChains don't have to do any error-handling themselves, removing the need for "CreateSafeFilter".

The debanding shader has been modified a bit in another attempt to distinguish better between detail and banding.

The colour conversions of SuperRes have been optimized, it no longer uses L*a*b (although doing so wouldn't have too big an impact on performance). Also disabled softness, it didn't work well enough. I'm still planning to do something with the setting (not sure what though) so I'll leave it in the dialog for now.

Also added a (very) minor optimization for SuperChromaRes.