### PR TITLE
Subtitle: Add support for Drag and Drop

### DIFF
--- a/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
+++ b/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
@@ -25,6 +25,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
 {
     public class SubtitleDragAndDrop : PlayerExtension
     {
+        private string m_SubtitleFile;
         public override ExtensionUiDescriptor Descriptor
         {
             get
@@ -47,6 +48,16 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
         {
             base.Initialize();
             Player.DragDrop += PlayerOnDragDrop;
+            Player.StateChanged +=PlayerOnStateChanged;
+        }
+
+        private void PlayerOnStateChanged(object sender, PlayerStateEventArgs playerStateEventArgs)
+        {
+            if (playerStateEventArgs.OldState == PlayerState.Closed && m_SubtitleFile != null)
+            {
+                LoadSubtitleFile(m_SubtitleFile);
+                m_SubtitleFile = null;
+            } 
         }
 
         private void PlayerOnDragDrop(object sender, PlayerControlEventArgs<DragEventArgs> playerControlEventArgs)
@@ -60,10 +71,15 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
             }
         }
 
-        private static void LoadSubtitleFile(string file)
+        private void LoadSubtitleFile(string file)
         {
             if (Player.State == PlayerState.Closed)
+            {
+                m_SubtitleFile = file;
+                //Player.OsdText.Show("Subtitle will be loaded with media", 3000); //Doesn't seem to work
                 return;
+            }
+
             Media.Pause(false);
             var subtitleLoaded = string.Format("Subtitle Loaded: {0}", Path.GetFileName(file));
             Player.OsdText.Show(SubtitleManager.LoadFile(file)
@@ -76,6 +92,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
         {
             base.Destroy();
             Player.DragDrop -= PlayerOnDragDrop;
+            Player.StateChanged -= PlayerOnStateChanged;
         }
     }
 }

--- a/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
+++ b/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
@@ -1,0 +1,86 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using Mpdn.Extensions.Framework;
+
+namespace Mpdn.Extensions.PlayerExtensions.Subtitles
+{
+    public class SubtitleDragAndDrop : PlayerExtension
+    {
+
+        public override ExtensionUiDescriptor Descriptor
+        {
+            get
+            {
+                return new ExtensionUiDescriptor
+                {
+                    Guid = new Guid("A2B9AF1B-C1A7-4338-9D75-012B4690C865"),
+                    Name = "Subtitle Drag and Drop",
+                    Description = "Add Drag and Drop support for subtitle"
+                };
+            }
+        }
+
+        protected override string ConfigFileName
+        {
+            get { return "SubtitleDragAndDrop"; }
+        }
+
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            Player.DragDrop +=PlayerOnDragDrop;
+        }
+
+
+        private void PlayerOnDragDrop(object sender, PlayerControlEventArgs<DragEventArgs> playerControlEventArgs)
+        {
+            var files = (string[])playerControlEventArgs.InputArgs.Data.GetData(DataFormats.FileDrop);
+            foreach (var file in files.Where(SubtitleManager.IsSubtitleFile))
+            {
+                playerControlEventArgs.Handled = true;
+                LoadSubtitleFile(file);
+                break;
+            }
+        }
+
+        private static void LoadSubtitleFile(string file)
+        {
+            if (Player.State == PlayerState.Closed)
+                return;
+            Media.Pause(false);
+            var subtitleLoaded = string.Format("Subtitle Loaded: {0}", Path.GetFileName(file));
+            Player.OsdText.Show(SubtitleManager.LoadFile(file)
+                ? subtitleLoaded
+                : "Impossible to load Subtitle file.");
+            Media.Play(false);
+        }
+
+        public override void Destroy()
+        {
+            base.Destroy();
+            Player.DragDrop -= PlayerOnDragDrop;
+
+        }
+    }
+}

--- a/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
+++ b/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
@@ -16,7 +16,6 @@
 // 
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -26,7 +25,6 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
 {
     public class SubtitleDragAndDrop : PlayerExtension
     {
-
         public override ExtensionUiDescriptor Descriptor
         {
             get
@@ -45,17 +43,15 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
             get { return "SubtitleDragAndDrop"; }
         }
 
-
         public override void Initialize()
         {
             base.Initialize();
-            Player.DragDrop +=PlayerOnDragDrop;
+            Player.DragDrop += PlayerOnDragDrop;
         }
-
 
         private void PlayerOnDragDrop(object sender, PlayerControlEventArgs<DragEventArgs> playerControlEventArgs)
         {
-            var files = (string[])playerControlEventArgs.InputArgs.Data.GetData(DataFormats.FileDrop);
+            var files = (string[]) playerControlEventArgs.InputArgs.Data.GetData(DataFormats.FileDrop);
             foreach (var file in files.Where(SubtitleManager.IsSubtitleFile))
             {
                 playerControlEventArgs.Handled = true;
@@ -80,7 +76,6 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
         {
             base.Destroy();
             Player.DragDrop -= PlayerOnDragDrop;
-
         }
     }
 }

--- a/Extensions/PlayerExtensions/Subtitles/SubtitleManager.cs
+++ b/Extensions/PlayerExtensions/Subtitles/SubtitleManager.cs
@@ -28,6 +28,22 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
 {
     public static class SubtitleManager
     {
+        [Flags]
+        private enum SubType
+        {
+            SRT = 0,
+            SUB,
+            SMI,
+            PSB,
+            SSA,
+            ASS,
+            IDX,
+            USF,
+            XSS,
+            TXT,
+            RT,
+            SUP
+        };
         public class SubtitleTiming
         {
             public int Delay { get; set; }
@@ -148,6 +164,20 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
             });
             return true;
         }
+        /// <summary>
+        /// Check if the extension of the file is linked to a Subtitle format.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
+        public static bool IsSubtitleFile(string file)
+        {
+            var extension = Path.GetExtension(file);
 
+            if (extension == null)
+                return false;
+
+            var ext = extension.Remove(0,1);
+            return Enum.IsDefined(typeof (SubType), ext.ToUpper());
+        }
     }
 }

--- a/Mpdn.Extensions.csproj
+++ b/Mpdn.Extensions.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Extensions\PlayerExtensions\FullScreenDisplaySelector.ConfigDialog.Designer.cs">
       <DependentUpon>FullScreenDisplaySelector.ConfigDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Extensions\PlayerExtensions\Subtitles\SubtitleDragAndDrop.cs" />
     <Compile Include="Extensions\PlayerExtensions\Subtitles\SubtitleDelay.cs" />
     <Compile Include="Extensions\PlayerExtensions\Subtitles\Subtitle.cs" />
     <Compile Include="Extensions\PlayerExtensions\Subtitles\SubtitleManager.cs" />


### PR DESCRIPTION
With this new extension the user can Drag and Drop subtitle file in MPDN, the player will detect them as Subtitle and load them using the COM Interface.

If multiple subtitle are dropped only the first one is loaded.