### PR TITLE
String conversions and Copy/Paste-ing

### DIFF
--- a/Extensions/Framework/Config/ExtensionsUi.cs
+++ b/Extensions/Framework/Config/ExtensionsUi.cs
@@ -100,6 +100,16 @@ namespace Mpdn.Extensions.Framework.Config
 
         public abstract ExtensionUiDescriptor Descriptor { get; }
 
+        public bool SaveToString(out string result)
+        {
+            return ScriptConfig.SaveToString(out result);
+        }
+
+        public bool LoadFromString(string input)
+        {
+            return ScriptConfig.LoadFromString(input);
+        }
+
         #region Implementation
 
         private IScriptSettings<TSettings> ScriptConfig { get; set; }

--- a/Extensions/Framework/Config/ScriptSettingsBase.cs
+++ b/Extensions/Framework/Config/ScriptSettingsBase.cs
@@ -58,7 +58,7 @@ namespace Mpdn.Extensions.Framework.Config
 
         public virtual bool LoadFromString(string input)
         {
-            return Settings.Load(out m_LastException);
+            return Settings.LoadFromString(input, out m_LastException);
         }
 
         public virtual bool SaveToString(out string output)

--- a/Extensions/Framework/Controls/RenderChainList.Designer.cs
+++ b/Extensions/Framework/Controls/RenderChainList.Designer.cs
@@ -39,6 +39,10 @@
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.menuChain = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.menuConfigure = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.menuRemove = new System.Windows.Forms.ToolStripMenuItem();
             this.menuClear = new System.Windows.Forms.ToolStripMenuItem();
@@ -95,7 +99,7 @@
             this.splitContainer.Panel2.Controls.Add(this.labelCopyright);
             this.splitContainer.Panel2.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.splitContainer.Size = new System.Drawing.Size(877, 551);
-            this.splitContainer.SplitterDistance = 433;
+            this.splitContainer.SplitterDistance = 432;
             this.splitContainer.TabIndex = 10;
             this.splitContainer.SplitterMoved += new System.Windows.Forms.SplitterEventHandler(this.SplitterMoved);
             // 
@@ -111,25 +115,25 @@
             // 
             this.buttonMinus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonMinus.Enabled = false;
-            this.buttonMinus.Location = new System.Drawing.Point(403, 524);
+            this.buttonMinus.Location = new System.Drawing.Point(402, 524);
             this.buttonMinus.Name = "buttonMinus";
             this.buttonMinus.Size = new System.Drawing.Size(27, 24);
             this.buttonMinus.TabIndex = 2;
             this.buttonMinus.Text = "-";
             this.buttonMinus.UseVisualStyleBackColor = true;
-            this.buttonMinus.Click += new System.EventHandler(this.ButtonMinusClick);
+            this.buttonMinus.Click += new System.EventHandler(this.ButtonMinusClicked);
             // 
             // buttonClear
             // 
             this.buttonClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonClear.Enabled = false;
-            this.buttonClear.Location = new System.Drawing.Point(370, 524);
+            this.buttonClear.Location = new System.Drawing.Point(369, 524);
             this.buttonClear.Name = "buttonClear";
             this.buttonClear.Size = new System.Drawing.Size(27, 24);
             this.buttonClear.TabIndex = 3;
             this.buttonClear.Text = "c";
             this.buttonClear.UseVisualStyleBackColor = true;
-            this.buttonClear.Click += new System.EventHandler(this.ButtonClearClick);
+            this.buttonClear.Click += new System.EventHandler(this.ButtonClearClicked);
             // 
             // listViewChain
             // 
@@ -146,7 +150,7 @@
             this.listViewChain.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
             this.listViewChain.Location = new System.Drawing.Point(3, 3);
             this.listViewChain.Name = "listViewChain";
-            this.listViewChain.Size = new System.Drawing.Size(427, 515);
+            this.listViewChain.Size = new System.Drawing.Size(426, 515);
             this.listViewChain.TabIndex = 4;
             this.listViewChain.UseCompatibleStateImageBehavior = false;
             this.listViewChain.View = System.Windows.Forms.View.Details;
@@ -154,7 +158,7 @@
             this.listViewChain.SelectedIndexChanged += new System.EventHandler(this.ListViewChainSelectedIndexChanged);
             this.listViewChain.DragDrop += new System.Windows.Forms.DragEventHandler(this.ListDragDrop);
             this.listViewChain.DragEnter += new System.Windows.Forms.DragEventHandler(this.ListDragEnter);
-            this.listViewChain.DoubleClick += new System.EventHandler(this.ButtonConfigureClick);
+            this.listViewChain.DoubleClick += new System.EventHandler(this.ButtonConfigureClicked);
             // 
             // columnHeader4
             // 
@@ -176,6 +180,10 @@
             // 
             this.menuChain.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuConfigure,
+            this.toolStripSeparator3,
+            this.copyToolStripMenuItem,
+            this.cutToolStripMenuItem,
+            this.pasteToolStripMenuItem,
             this.toolStripSeparator1,
             this.menuRemove,
             this.menuClear,
@@ -184,7 +192,7 @@
             this.menuGroup,
             this.menuUngroup});
             this.menuChain.Name = "contextMenuStrip1";
-            this.menuChain.Size = new System.Drawing.Size(165, 148);
+            this.menuChain.Size = new System.Drawing.Size(165, 220);
             this.menuChain.Opening += new System.ComponentModel.CancelEventHandler(this.MenuChainOpening);
             // 
             // menuConfigure
@@ -193,7 +201,36 @@
             this.menuConfigure.Size = new System.Drawing.Size(164, 22);
             this.menuConfigure.Text = "Configure...";
             this.menuConfigure.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.MenuConfigureItemClicked);
-            this.menuConfigure.Click += new System.EventHandler(this.ButtonConfigureClick);
+            this.menuConfigure.Click += new System.EventHandler(this.ButtonConfigureClicked);
+            // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(161, 6);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.copyToolStripMenuItem.Text = "Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.MenuChainCopyClicked);
+            // 
+            // cutToolStripMenuItem
+            // 
+            this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
+            this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.cutToolStripMenuItem.Text = "Cut";
+            this.cutToolStripMenuItem.Click += new System.EventHandler(this.MenuChainCutClicked);
+            // 
+            // pasteToolStripMenuItem
+            // 
+            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.pasteToolStripMenuItem.Text = "Paste";
+            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.MenuChainPasteClicked);
             // 
             // toolStripSeparator1
             // 
@@ -206,14 +243,14 @@
             this.menuRemove.ShortcutKeys = System.Windows.Forms.Keys.Delete;
             this.menuRemove.Size = new System.Drawing.Size(164, 22);
             this.menuRemove.Text = "Remove";
-            this.menuRemove.Click += new System.EventHandler(this.ButtonMinusClick);
+            this.menuRemove.Click += new System.EventHandler(this.ButtonMinusClicked);
             // 
             // menuClear
             // 
             this.menuClear.Name = "menuClear";
             this.menuClear.Size = new System.Drawing.Size(164, 22);
             this.menuClear.Text = "Clear";
-            this.menuClear.Click += new System.EventHandler(this.ButtonClearClick);
+            this.menuClear.Click += new System.EventHandler(this.ButtonClearClicked);
             // 
             // menuSelectAll
             // 
@@ -233,14 +270,14 @@
             this.menuGroup.Name = "menuGroup";
             this.menuGroup.Size = new System.Drawing.Size(164, 22);
             this.menuGroup.Text = "Group";
-            this.menuGroup.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.MenuGroupItemClicked);
+            this.menuGroup.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.MenuChainGroupClicked);
             // 
             // menuUngroup
             // 
             this.menuUngroup.Name = "menuUngroup";
             this.menuUngroup.Size = new System.Drawing.Size(164, 22);
             this.menuUngroup.Text = "Ungroup";
-            this.menuUngroup.Click += new System.EventHandler(this.MenuUngroupClicked);
+            this.menuUngroup.Click += new System.EventHandler(this.MenuChainUngroupClicked);
             // 
             // buttonConfigure
             // 
@@ -252,7 +289,7 @@
             this.buttonConfigure.TabIndex = 5;
             this.buttonConfigure.Text = "Configure...";
             this.buttonConfigure.UseVisualStyleBackColor = true;
-            this.buttonConfigure.Click += new System.EventHandler(this.ButtonConfigureClick);
+            this.buttonConfigure.Click += new System.EventHandler(this.ButtonConfigureClicked);
             // 
             // NameLable
             // 
@@ -270,7 +307,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.NameBox.Location = new System.Drawing.Point(179, 526);
             this.NameBox.Name = "NameBox";
-            this.NameBox.Size = new System.Drawing.Size(185, 20);
+            this.NameBox.Size = new System.Drawing.Size(184, 20);
             this.NameBox.TabIndex = 10;
             this.NameBox.TextChanged += new System.EventHandler(this.NameChanged);
             this.NameBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.NameKeyDown);
@@ -301,7 +338,7 @@
             this.buttonUp.TabIndex = 0;
             this.buttonUp.Text = "▲";
             this.buttonUp.UseVisualStyleBackColor = true;
-            this.buttonUp.Click += new System.EventHandler(this.ButtonUpClick);
+            this.buttonUp.Click += new System.EventHandler(this.ButtonUpClicked);
             // 
             // buttonDown
             // 
@@ -317,7 +354,7 @@
             this.buttonDown.TabIndex = 1;
             this.buttonDown.Text = "▼";
             this.buttonDown.UseVisualStyleBackColor = true;
-            this.buttonDown.Click += new System.EventHandler(this.ButtonDownClick);
+            this.buttonDown.Click += new System.EventHandler(this.ButtonDownClicked);
             // 
             // listViewAvail
             // 
@@ -334,7 +371,7 @@
             this.listViewAvail.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
             this.listViewAvail.Location = new System.Drawing.Point(3, 3);
             this.listViewAvail.Name = "listViewAvail";
-            this.listViewAvail.Size = new System.Drawing.Size(434, 515);
+            this.listViewAvail.Size = new System.Drawing.Size(435, 515);
             this.listViewAvail.TabIndex = 0;
             this.listViewAvail.UseCompatibleStateImageBehavior = false;
             this.listViewAvail.View = System.Windows.Forms.View.Details;
@@ -342,7 +379,7 @@
             this.listViewAvail.SelectedIndexChanged += new System.EventHandler(this.ListViewSelectedIndexChanged);
             this.listViewAvail.DragDrop += new System.Windows.Forms.DragEventHandler(this.ListDragDropRemove);
             this.listViewAvail.DragEnter += new System.Windows.Forms.DragEventHandler(this.ListDragEnter);
-            this.listViewAvail.DoubleClick += new System.EventHandler(this.ButtonAddClick);
+            this.listViewAvail.DoubleClick += new System.EventHandler(this.ButtonAddClicked);
             // 
             // columnHeader3
             // 
@@ -372,7 +409,7 @@
             this.menuAdd.Name = "menuAdd";
             this.menuAdd.Size = new System.Drawing.Size(96, 22);
             this.menuAdd.Text = "Add";
-            this.menuAdd.Click += new System.EventHandler(this.ButtonAddClick);
+            this.menuAdd.Click += new System.EventHandler(this.ButtonAddClicked);
             // 
             // buttonAdd
             // 
@@ -384,7 +421,7 @@
             this.buttonAdd.TabIndex = 1;
             this.buttonAdd.Text = "+";
             this.buttonAdd.UseVisualStyleBackColor = true;
-            this.buttonAdd.Click += new System.EventHandler(this.ButtonAddClick);
+            this.buttonAdd.Click += new System.EventHandler(this.ButtonAddClicked);
             // 
             // labelCopyright
             // 
@@ -392,7 +429,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.labelCopyright.Location = new System.Drawing.Point(36, 523);
             this.labelCopyright.Name = "labelCopyright";
-            this.labelCopyright.Size = new System.Drawing.Size(401, 24);
+            this.labelCopyright.Size = new System.Drawing.Size(402, 24);
             this.labelCopyright.TabIndex = 2;
             this.labelCopyright.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -450,6 +487,9 @@
         private System.Windows.Forms.ToolStripMenuItem menuUngroup;
         private System.Windows.Forms.ContextMenuStrip menuAvail;
         private System.Windows.Forms.ToolStripMenuItem menuAdd;
-
+        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+        private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
     }
 }

--- a/Extensions/Framework/Controls/RenderChainList.cs
+++ b/Extensions/Framework/Controls/RenderChainList.cs
@@ -477,7 +477,7 @@ namespace Mpdn.Extensions.Framework.Controls
 
         #region Buttons
 
-        private void ButtonConfigureClick(object sender, EventArgs e)
+        private void ButtonConfigureClicked(object sender, EventArgs e)
         {
             if (listViewChain.SelectedItems.Count <= 0)
                 return;
@@ -486,19 +486,19 @@ namespace Mpdn.Extensions.Framework.Controls
             ConfigureItem(item);
         }
 
-        private void ButtonAddClick(object sender, EventArgs e)
+        private void ButtonAddClicked(object sender, EventArgs e)
         {
             foreach (ListViewItem item in listViewAvail.SelectedItems)
                 AddScript((IRenderChainUi)item.Tag);
         }
 
-        private void ButtonMinusClick(object sender, EventArgs e)
+        private void ButtonMinusClicked(object sender, EventArgs e)
         {
             foreach (ListViewItem item in listViewChain.SelectedItems)
                 RemoveItem(item);
         }
 
-        private void ButtonClearClick(object sender, EventArgs e)
+        private void ButtonClearClicked(object sender, EventArgs e)
         {
             while (listViewChain.Items.Count > 0)
             {
@@ -507,13 +507,13 @@ namespace Mpdn.Extensions.Framework.Controls
             UpdateButtons();
         }
 
-        private void ButtonUpClick(object sender, EventArgs e)
+        private void ButtonUpClicked(object sender, EventArgs e)
         {
             MoveListViewItems(listViewChain, MoveDirection.Up);
             UpdateButtons();
         }
 
-        private void ButtonDownClick(object sender, EventArgs e)
+        private void ButtonDownClicked(object sender, EventArgs e)
         {
             MoveListViewItems(listViewChain, MoveDirection.Down);
             UpdateButtons();
@@ -626,7 +626,7 @@ namespace Mpdn.Extensions.Framework.Controls
 
         #region (Un)Grouping
 
-        private void MenuGroupItemClicked(object sender, ToolStripItemClickedEventArgs e)
+        private void MenuChainGroupClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             var script = (IRenderChainUi)e.ClickedItem.Tag;
             var grouppreset = script.MakeNewPreset();
@@ -646,7 +646,7 @@ namespace Mpdn.Extensions.Framework.Controls
             listViewChain.SelectedIndices.Add(index);
         }
 
-        private void MenuUngroupClicked(object sender, EventArgs e)
+        private void MenuChainUngroupClicked(object sender, EventArgs e)
         {
             if (listViewChain.SelectedItems.Count == 1)
             {
@@ -706,6 +706,38 @@ namespace Mpdn.Extensions.Framework.Controls
                 && preset.ShowConfigDialog(ParentForm.Owner)
                 && listViewChain.SelectedItems.Count > 0)
                 UpdateItemText(listViewChain.SelectedItems[0]);
+        }
+
+        #endregion
+
+        #region Copy / Pasting
+
+        private void MenuChainCopyClicked(object sender, EventArgs e)
+        {
+            List<Preset> items = listViewChain.SelectedItems
+                .Cast<ListViewItem>()
+                .Select(item => (Preset)item.Tag)
+                .ToList();
+
+            var text = ConfigHelper.SaveToString(items);
+            Clipboard.SetText(text);
+        }
+
+        private void MenuChainCutClicked(object sender, EventArgs e)
+        {
+            MenuChainCopyClicked(sender, e);
+            ButtonMinusClicked(sender, e);
+        }
+
+        private void MenuChainPasteClicked(object sender, EventArgs e)
+        {
+            if (Clipboard.ContainsText())
+            {
+                var text = Clipboard.GetText();
+                var items = ConfigHelper.LoadFromString<List<Preset>>(text);
+                if (items != null)
+                    AddPresets(items, SelectedIndex+1);
+            }
         }
 
         #endregion

--- a/Extensions/Framework/Helpers.cs
+++ b/Extensions/Framework/Helpers.cs
@@ -31,6 +31,7 @@ using Mpdn.AudioScript;
 using Mpdn.Config;
 using Mpdn.DirectShow;
 using Mpdn.RenderScript;
+using Mpdn.Extensions.Framework.Config;
 using Control = System.Windows.Forms.Control;
 using WaveFormatExtensible = DirectShowLib.WaveFormatExtensible;
 
@@ -90,6 +91,31 @@ namespace Mpdn.Extensions.Framework
                 return Path.Combine(GetDirectoryName(Assembly.GetAssembly(typeof(IPlayerExtension)).Location),
                     "Extensions");
             }
+        }
+    }
+
+    public static class ConfigHelper
+    {
+        public static string SaveToString<TSettings>(TSettings settings)
+            where TSettings : class, new()
+        {
+            string result;
+
+            var config = new MemConfig<TSettings>(settings);
+            if (config.SaveToString(out result))
+                return result;
+            else
+                return null;
+        }
+
+        public static TSettings LoadFromString<TSettings>(string input)
+            where TSettings : class, new()
+        {
+            var config = new MemConfig<TSettings>();
+            if (config.LoadFromString(input))
+                return config.Config;
+            else
+                return null;
         }
     }
 
@@ -791,7 +817,7 @@ namespace Mpdn.Extensions.Framework
         {
             PlayerControl.ClearScreen();
         }
-
+            
         public static void ShowOptionsDialog()
         {
             PlayerControl.ShowOptionsDialog();

--- a/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
+++ b/Extensions/PlayerExtensions/Subtitles/SubtitleDragAndDrop.cs
@@ -63,6 +63,8 @@ namespace Mpdn.Extensions.PlayerExtensions.Subtitles
         private void PlayerOnDragDrop(object sender, PlayerControlEventArgs<DragEventArgs> playerControlEventArgs)
         {
             var files = (string[]) playerControlEventArgs.InputArgs.Data.GetData(DataFormats.FileDrop);
+
+            if (files != null)
             foreach (var file in files.Where(SubtitleManager.IsSubtitleFile))
             {
                 playerControlEventArgs.Handled = true;

--- a/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
@@ -37,9 +37,8 @@ namespace Mpdn.Extensions.RenderScripts
                 get { return m_Hotkey; }
                 set
                 {
-                    DeregisterHotkey();
                     m_Hotkey = value ?? "";
-                    RegisterHotkey();
+                    UpdateHotkey();
                 }
             }
 
@@ -55,7 +54,7 @@ namespace Mpdn.Extensions.RenderScripts
                 get
                 {
                     var preset = SelectedOption;
-                    return preset == null ? string.Empty : preset.Name;
+                    return preset == null ? string.Empty : preset.Name; 
                 }
                 set
                 {
@@ -106,17 +105,28 @@ namespace Mpdn.Extensions.RenderScripts
             #region Hotkey Handling
 
             private readonly Guid m_HotkeyGuid;
-
             private string m_Hotkey;
+            private bool m_Registered;
 
             private void RegisterHotkey()
             {
                 DynamicHotkeys.RegisterHotkey(m_HotkeyGuid, Hotkey, IncrementSelection);
+                m_Registered = true;
             }
 
             private void DeregisterHotkey()
             {
                 DynamicHotkeys.RemoveHotkey(m_HotkeyGuid);
+                m_Registered = false;
+            }
+
+            private void UpdateHotkey()
+            {
+                if (m_Registered)
+                {
+                    DeregisterHotkey();
+                    RegisterHotkey();
+                }
             }
 
             private void IncrementSelection()


### PR DESCRIPTION
Added several ways to use the Config framework to convert objects to and from strings. Consisting of one general "ConfigHelper" and some functions specific to ExtensionUis.

Extended RenderChainList to use these functions for copy / pasting renderscripts. This way you can paste and copy renderscripts as text.

Also fixed some bugs.