### PR TITLE
Chroma Scaling: Support MPDN's internal chroma scaling. Make ChromaFi…

### DIFF
--- a/Extensions/RenderScripts/Mpdn.EwaChromaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaChromaScaler.cs
@@ -34,7 +34,8 @@ namespace Mpdn.Extensions.RenderScripts
             {
                 var chromaFilter = input as ChromaFilter;
                 if (chromaFilter != null)
-                    chromaFilter.ChromaScaler = this;
+                    return chromaFilter.MakeNew(this);
+
                 return input;
             }
 

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
@@ -76,7 +76,8 @@ namespace Mpdn.Extensions.RenderScripts
             {
                 var chromaFilter = input as ChromaFilter;
                 if (chromaFilter != null)
-                    chromaFilter.ChromaScaler = this;
+                    return chromaFilter.MakeNew(this);
+
                 return input;
             }
 

--- a/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
@@ -94,7 +94,8 @@ namespace Mpdn.Extensions.RenderScripts
             {
                 var chromaFilter = input as ChromaFilter;
                 if (chromaFilter != null)
-                    chromaFilter.ChromaScaler = this;
+                    return chromaFilter.MakeNew(this);
+
                 return input;
             }
 

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Chroma.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Chroma.Scaler.cs
@@ -75,7 +75,8 @@ namespace Mpdn.Extensions.RenderScripts
             {
                 var chromaFilter = input as ChromaFilter;
                 if (chromaFilter != null)
-                    chromaFilter.ChromaScaler = this;
+                    return chromaFilter.MakeNew(this);
+
                 return input;
             }
 

--- a/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperChromaRes.cs
@@ -64,7 +64,8 @@ namespace Mpdn.Extensions.RenderScripts
             {
                 var chromaFilter = input as ChromaFilter;
                 if (chromaFilter != null)
-                    chromaFilter.ChromaScaler = this;
+                    return chromaFilter.MakeNew(this);
+
                 return input;
             }
 


### PR DESCRIPTION
…lter Immutable.

Immutable filters tend to lead to less bugs, although they're slightly
more difficult to deal with. This also makes it easier to use the output
of different chroma scaler inside of a different chroma scaler, which is
convenient for SuperChromaRes.

MPDN's internal chroma scalers are used if no changes are made, but this
functionality is somewhat limited. And performance wise it doesn't seem
to make much of a difference.

Fixes #152.