### PR TITLE
Updatechecker: fixes #164 and use JSON instead of Text

### DIFF
--- a/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.PlayerExtension.cs
@@ -112,27 +112,30 @@ namespace Mpdn.Extensions.PlayerExtensions.UpdateChecker
         {
             var playerNeedUpdate = Settings.MpdnVersionOnServer > m_CurrentVersion;
             var extensionNeedUpdate = Settings.ExtensionVersionOnServer > ExtensionUpdateChecker.GetExtensionsVersion();
+
+            var displayForm = new Func<bool>(() => Settings.UseSimpleUpdate
+                ? DisplaySimpleForm(force, playerNeedUpdate, extensionNeedUpdate)
+                : DisplayAdvancedForm(force, playerNeedUpdate, extensionNeedUpdate));
+
             //Check API Version match when both updates available
             if (playerNeedUpdate && extensionNeedUpdate &&
-                Settings.MpdnVersionOnServer.ExtensionApiVersion !=
+                Settings.MpdnVersionOnServer.ExtensionApiVersion ==
                 Settings.ExtensionVersionOnServer.ExtensionApiVersion)
             {
-                return false;
+                return displayForm.Invoke();
             }
-            //Don't update player if the update is going to break the extensions.
-            if (playerNeedUpdate && Settings.MpdnVersionOnServer.ExtensionApiVersion != Extension.InterfaceVersion)
+            //Update player if the update is going to break the extensions.
+            if (playerNeedUpdate && Settings.MpdnVersionOnServer.ExtensionApiVersion == Extension.InterfaceVersion)
             {
-                return false;
+                return displayForm.Invoke();
             }
-            //Don't update the extension if the new extensions aren't going to work with the current player.
+            //Update the extension if the new extensions aren't going to work with the current player.
             if (extensionNeedUpdate &&
-                Settings.ExtensionVersionOnServer.ExtensionApiVersion != Extension.InterfaceVersion)
+                Settings.ExtensionVersionOnServer.ExtensionApiVersion == Extension.InterfaceVersion)
             {
-                return false;
+                return displayForm.Invoke();
             }
-            return Settings.UseSimpleUpdate
-                ? DisplaySimpleForm(force, playerNeedUpdate, extensionNeedUpdate)
-                : DisplayAdvancedForm(force, playerNeedUpdate, extensionNeedUpdate);
+            return false;
         }
 
         private bool DisplayAdvancedForm(bool force, bool playerNeedUpdate, bool extensionNeedUpdate)

--- a/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.Version.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.Version.cs
@@ -207,4 +207,11 @@ namespace Mpdn.Extensions.PlayerExtensions.UpdateChecker
             return list;
         }
     }
+
+    public class JsonVersion
+    {
+        public string Version { get; set; }
+        public List<string> Changelog { get; set; }
+        public int API { get; set; }
+    }
 }


### PR DESCRIPTION
Use JSON instead of text to provide update information for the player. 

http://mpdn.zachsaw.com/LatestVersion.json

Old URL still available and working as before for retrocompatibility.

http://mpdn.zachsaw.com/LatestVersion.txt