### PR TITLE
Status system overhaul

### DIFF
--- a/Extensions/Framework/Helpers.cs
+++ b/Extensions/Framework/Helpers.cs
@@ -324,11 +324,16 @@ namespace Mpdn.Extensions.Framework
 
     public static class StatusHelpers
     {
+        public static string FlattenStatus(this string status)
+        {
+            return status.Replace(';', ',');
+        }
+
         public static string ToSubStatus(this string status)
         {
             return string.IsNullOrEmpty(status)
                 ? ""
-                : string.Format("({0})", status.Replace(';', ','));
+                : string.Format("({0})", FlattenStatus(status));
         }
 
         public static string AppendSubStatus(this string first, string status)
@@ -353,26 +358,14 @@ namespace Mpdn.Extensions.Framework
 
         public static string PrependToStatus(this string status, string prefix)
         {
-            return (status != "")
-                ? prefix + status
-                : status;
+            return (string.IsNullOrEmpty(status))
+                ? status
+                : prefix + status;
         }
 
         public static Func<string> Append(this Func<string> first, Func<string> status)
         {
             return () => first().AppendStatus(status());
-        }
-
-        public static string AppendChromaStatus(this string status, IChromaScaler chromaScaler, IScaler fallbackScaler)
-        {
-            var chroma = chromaScaler as RenderChain.RenderChain;
-            if (chroma == null) return status;
-            var chromaStatus = chroma.Status();
-            chromaStatus = string.IsNullOrEmpty(chromaStatus)
-                ? fallbackScaler.GetDescription() + " Chroma"
-                : chromaStatus;
-
-            return status.AppendSubStatus(chromaStatus);
         }
 
         public static string ScaleDescription(TextureSize inputSize, TextureSize outputSize, IScaler upscaler, IScaler downscaler, IScaler convolver = null)

--- a/Extensions/Framework/RenderChain/Filter.Chroma.cs
+++ b/Extensions/Framework/RenderChain/Filter.Chroma.cs
@@ -32,7 +32,9 @@ namespace Mpdn.Extensions.Framework.RenderChain
             var fullSizeChroma = new ResizeFilter(chromaInput, targetSize, TextureChannels.ChromaOnly, 
                 chromaOffset, Renderer.ChromaUpscaler, Renderer.ChromaDownscaler);
 
-            return new MergeFilter(lumaInput.SetSize(targetSize), fullSizeChroma).ConvertToRgb();
+            return new MergeFilter(lumaInput.SetSize(targetSize, tagged: true), fullSizeChroma)
+                .ConvertToRgb()
+                .Tagged(new ChromaScalerTag(chromaInput, fullSizeChroma.Status().PrependToStatus("Chroma: ")));
         }
     }
 
@@ -48,7 +50,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public IFilter CreateChromaFilter(IFilter lumaInput, IFilter chromaInput, TextureSize targetSize, Vector2 chromaOffset)
         {
             if (lumaInput is YSourceFilter && chromaInput is ChromaSourceFilter && chromaOffset == Renderer.ChromaOffset)
-                return m_SourceFilter.SetSize(targetSize);
+                return m_SourceFilter.SetSize(targetSize, tagged: true);
 
             return null;
         }
@@ -56,62 +58,20 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
     public static class ChromaHelper
     {
-        public static IFilter MakeChromaFilter(this IChromaScaler chromaScaler, IFilter lumaInput, IFilter chromaInput, TextureSize targetSize, Vector2 chromaOffset)
-        {
-            var chain = chromaScaler as RenderChain;
-            if (chain != null)
-            {
-                chain.Status = null;
-            }
-
-            IFilter result;
-            try
-            {
-                result = chromaScaler.CreateChromaFilter(lumaInput, chromaInput, targetSize, chromaOffset);
-            }
-            catch (Exception)
-            {
-                if (chain != null)
-                {
-                    chain.Status = chain.Inactive;
-                }
-                throw;
-            }
-
-            if (chain == null)
-                return result;
-
-            var activeStatus = chain.Status ?? chain.Active;
-            chain.Status = () => result != null ? activeStatus() : chain.Inactive();
-
-            return result;
-        }
-
         public static IFilter CreateChromaFilter(this IChromaScaler chromaScaler, IFilter lumaInput, IFilter chromaInput, Vector2 chromaOffset)
         {
-            return chromaScaler.MakeChromaFilter(lumaInput, chromaInput, lumaInput.OutputSize, chromaOffset);
+            return chromaScaler.CreateChromaFilter(lumaInput, chromaInput, lumaInput.OutputSize, chromaOffset);
         }
 
         public static IFilter MakeChromaFilter<TChromaScaler>(this TChromaScaler scaler, IFilter input)
             where TChromaScaler : RenderChain, IChromaScaler
         {
             var chromaFilter = input as ChromaFilter;
-            if (chromaFilter != null)
-                return chromaFilter.MakeNew(scaler);
+            if (chromaFilter == null)
+                return input;
 
-            scaler.Status = scaler.Inactive;
-            return input;
-        }
-
-        public static Func<string> ChromaScalerStatus<TChromaScaler>(this TChromaScaler chromaScaler, IFilter resizedLuma)
-            where TChromaScaler : RenderChain, IChromaScaler
-        {
-            return delegate
-            {
-                var lumaStatus = resizedLuma.ResizerDescription();
-                var chromaStatus = chromaScaler.Active();
-                return lumaStatus != "" ? string.Format("Chroma: {0}; Luma:{1}", chromaStatus, lumaStatus) : chromaStatus;
-            };
+            return chromaFilter.MakeNew(scaler)
+                    .Tagged(new TemporaryTag("ChromaScaler"));
         }
     }
 
@@ -127,20 +87,21 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
         public TextureSize TargetSize;
 
-        public ChromaFilter(IFilter lumaInput, IFilter chromaInput, IFilter fallback = null, IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null)
+        public ChromaFilter(IFilter lumaInput, IFilter chromaInput, TextureSize? targetSize = null, Vector2? chromaOffset = null, IFilter fallback = null, IChromaScaler chromaScaler = null)
         {
             Luma = lumaInput;
             Chroma = chromaInput;
+            TargetSize = targetSize ?? lumaInput.OutputSize;
             ChromaOffset = chromaOffset ?? Renderer.ChromaOffset;
             ChromaScaler = chromaScaler ?? new DefaultChromaScaler();
-            TargetSize = targetSize ?? lumaInput.OutputSize;
 
             m_Fallback = fallback ?? MakeNew();
+            Tag = new EmptyTag();
         }
 
         public ChromaFilter MakeNew(IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null)
         {
-            return new ChromaFilter(Luma, Chroma, this, chromaScaler ?? ChromaScaler, targetSize ?? TargetSize, chromaOffset ?? ChromaOffset);
+            return new ChromaFilter(Luma, Chroma, targetSize ?? TargetSize, chromaOffset ?? ChromaOffset, this, chromaScaler ?? ChromaScaler);
         }
 
         public override ITexture2D OutputTexture
@@ -158,21 +119,31 @@ namespace Mpdn.Extensions.Framework.RenderChain
             get { return Renderer.RenderQuality.GetTextureFormat(); } // Not guaranteed
         }
 
+        public void MakeTagged() { /* ChromaScaler is *always* tagged */ }
+
         public override IFilter<ITexture2D> Compile()
         {
             if (m_CompilationResult != null)
                 return m_CompilationResult;
 
-            m_CompilationResult =
-                (ChromaScaler.MakeChromaFilter(Luma, Chroma, TargetSize, ChromaOffset) ?? m_Fallback)
-                    .SetSize(TargetSize)
-                    .Compile();
-            return m_CompilationResult;
-        }
+            var result = ChromaScaler.CreateChromaFilter(Luma, Chroma, TargetSize, ChromaOffset);
 
-        public override bool Active
-        {
-           get { return base.Active || m_CompilationResult != null;  }
+            if (result == null)
+                result = m_Fallback;
+            else
+            {
+                var chain = ChromaScaler as RenderChain;
+                if (chain != null && result.Tag.IsEmpty())
+                    result.AddTag(new ChromaScalerTag(Chroma, chain.Status));
+            }
+
+            Tag.AddInput(result);
+
+            m_CompilationResult = result
+                .SetSize(TargetSize, tagged: true)
+                .Compile();
+
+            return m_CompilationResult;
         }
 
         public void SetSize(TextureSize size)

--- a/Extensions/Framework/RenderChain/Filter.Tag.cs
+++ b/Extensions/Framework/RenderChain/Filter.Tag.cs
@@ -1,0 +1,278 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using IBaseFilter = Mpdn.Extensions.Framework.RenderChain.IFilter<Mpdn.IBaseTexture>;
+
+namespace Mpdn.Extensions.Framework.RenderChain
+{
+    public abstract class FilterTag
+    {
+        public static readonly FilterTag Bottom = new BottomTag();
+
+        public abstract string Label { get; }
+
+        #region Base Implementation
+
+        private readonly List<IBaseFilter> m_FilterInputs = new List<IBaseFilter>();
+        private List<FilterTag> m_InputTags = new List<FilterTag>();
+
+        private int m_Index;
+        protected IEnumerable<FilterTag> SubTags { get; private set; }
+
+        protected bool Initialized { get { return m_Index != 0; } }
+
+        public virtual bool IsEmpty()
+        {
+            return string.IsNullOrEmpty(Label);
+        }
+
+        public virtual int Initialize(int count = 1)
+        {
+            if (Initialized)
+                return count;
+
+            var tags = new List<FilterTag>();
+            m_Index = count;
+            m_InputTags = m_InputTags.Concat(
+                    m_FilterInputs
+                    .Select(t => t.Tag))
+                    .Distinct()
+                    .ToList();
+
+            foreach (var input in m_InputTags)
+            {
+                m_Index = input.Initialize(m_Index);
+
+                if (input.IsEmpty())
+                    tags.AddRange(input.SubTags);
+                else
+                    tags.Add(input);
+            }
+            
+            SubTags = tags.Distinct().ToList();
+            return ++m_Index;
+        }
+
+        #endregion
+
+        #region Text rendering
+
+        public virtual string CreateString(int minIndex = -1)
+        {
+            Initialize();
+
+            string result = Label;
+            var tags = SubTags
+                .OrderBy(l => l.m_Index)
+                .SkipWhile(l => l.m_Index <= minIndex)
+                .ToList();
+
+            if (tags.Any())
+            {
+                var first = tags.First();
+                result = first
+                    .CreateString(minIndex)
+                    .AppendStatus(Label);
+                minIndex = first.m_Index;
+
+                foreach (var tag in tags.Skip(1))
+                {
+                    result = result.AppendSubStatus(tag.CreateString(minIndex));
+                    minIndex = tag.m_Index;
+                }
+            }
+            return result;
+        }
+
+        #endregion
+
+        #region Graph Operations
+
+        public void AddInput(IBaseFilter filter)
+        {
+            m_FilterInputs.Add(filter);
+        }
+
+        public void AddInputLabel(FilterTag tag)
+        {
+            m_InputTags.Add(tag);
+        }
+
+        public bool HasAncestor(FilterTag ancestor)
+        {
+            return (this == ancestor)
+                   || (     m_Index > ancestor.m_Index
+                       &&   m_InputTags.Any(t => t.HasAncestor(ancestor)));
+        }
+
+        public bool ConnectedTo(FilterTag tag)
+        {
+            return (m_Index < tag.m_Index)
+                ? tag.HasAncestor(this)
+                : this.HasAncestor(tag);
+        }
+
+        #endregion
+
+        #region String Operations
+
+        public override string ToString()
+        {
+            return Label ?? "";
+        }
+
+        public static implicit operator FilterTag(String label)
+        {
+            return new StringTag(label);
+        }
+
+        #endregion
+
+        private class BottomTag : StringTag
+        {
+            public BottomTag() : base("_|_") { }
+
+            public override int Initialize(int count = 1)
+            {
+                m_FilterInputs.Clear();
+                return count;
+            }
+
+            public override string CreateString(int minIndex = -1)
+            {
+                return "";
+            }
+        }
+    }
+
+    public class EmptyTag : FilterTag
+    {
+        public sealed override string Label { get { return ""; } }
+    }
+
+    public class StringTag : FilterTag
+    {
+        public override string Label { get; }
+
+        public StringTag(string label)
+        {
+            Label = label;
+        }
+    }
+
+    public class HiddenTag : StringTag
+    {
+        private bool m_Printing;
+
+        public HiddenTag(string label) : base(label) { }
+
+        public override string Label
+        {
+            get { return m_Printing ? "" : base.Label; }
+        }
+
+        public override string CreateString(int minIndex = -1)
+        {
+            Initialize();
+
+            m_Printing = true;
+            var result = base.CreateString(minIndex);
+            m_Printing = false;
+            return result;
+        }
+    }
+
+    public class TemporaryTag : StringTag
+    {
+        public TemporaryTag(string label) : base(label) { }
+
+        public override bool IsEmpty() { return Initialized; }
+    }
+
+    public class ChromaScalerTag : StringTag
+    {
+        private readonly IBaseFilter m_ChromaFilter;
+
+        private FilterTag m_ChromaTag;
+
+        public ChromaScalerTag(IBaseFilter chromaFilter, string label)
+            : base(label)
+        {
+            m_ChromaFilter = chromaFilter;
+
+            AddInput(m_ChromaFilter);
+        }
+
+        public override int Initialize(int count = 1)
+        {
+            if (!Initialized)
+            {
+                m_ChromaTag = m_ChromaFilter.Tag;
+            }
+
+            return base.Initialize(count);
+        }
+
+        public override string CreateString(int minIndex = -1)
+        {
+            Initialize();
+
+            var lumaPart = new EmptyTag();
+            var chromaPart = new StringTag(Label);
+
+            foreach (var tag in SubTags)
+                if (tag.ConnectedTo(m_ChromaTag))
+                    chromaPart.AddInputLabel(tag);
+                else
+                    lumaPart.AddInputLabel(tag);
+
+            lumaPart.Initialize();
+            chromaPart.Initialize();
+
+            var luma = lumaPart
+                .CreateString(minIndex)
+                .FlattenStatus()
+                .PrependToStatus("Luma: ");
+
+            var chroma = chromaPart
+                .CreateString(minIndex)
+                .FlattenStatus();
+            if (!chroma.StartsWith("Chroma: "))
+                chroma = chroma.PrependToStatus(luma == "" ? "" : "Chroma: ");
+
+            return chroma.AppendStatus(luma);
+        }
+    }
+
+    public static class TagHelper
+    {
+        public static bool IsNullOrEmpty(this FilterTag tag)
+        {
+            return tag == null || tag.IsEmpty();
+        }
+
+        public static FilterTag Append(this FilterTag tag, FilterTag newTag)
+        {
+            if (tag != null && newTag != null)
+                newTag.AddInputLabel(tag);
+
+            return newTag ?? tag;
+        }
+    }
+}

--- a/Extensions/Framework/RenderChain/Filter.Tag.cs
+++ b/Extensions/Framework/RenderChain/Filter.Tag.cs
@@ -137,7 +137,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
             return Label ?? "";
         }
 
-        public static implicit operator FilterTag(String label)
+        public static implicit operator FilterTag(string label)
         {
             return new StringTag(label);
         }

--- a/Extensions/Framework/RenderChain/Presets.cs
+++ b/Extensions/Framework/RenderChain/Presets.cs
@@ -123,13 +123,9 @@ namespace Mpdn.Extensions.Framework.RenderChain
                 Chain.Reset();
         }
 
-        public override Func<string> Status
-        {
-            get { return Script != null ? Chain.Status : Inactive; }
-            set { if (Script != null) Chain.Status = value; }
-        }
-
         #endregion
+
+        public override string Status { get { return null; } }
 
         public override string ToString()
         {
@@ -215,9 +211,9 @@ namespace Mpdn.Extensions.Framework.RenderChain
     {
         public IFilter CreateChromaFilter(IFilter lumaInput, IFilter chromaInput, TextureSize targetSize, Vector2 chromaOffset)
         {
-            IChromaScaler chromaScaler = Chain as IChromaScaler ?? new DefaultChromaScaler();
+            var chroma = new ChromaFilter(lumaInput, chromaInput, targetSize, chromaOffset);
 
-            return chromaScaler.MakeChromaFilter(lumaInput, chromaInput, targetSize, chromaOffset);
+            return chroma + Chain;
         }
     }
 

--- a/Extensions/Framework/RenderChain/RenderChainUi.cs
+++ b/Extensions/Framework/RenderChain/RenderChainUi.cs
@@ -39,8 +39,6 @@ namespace Mpdn.Extensions.Framework.RenderChain
         private class IdentityRenderChain : StaticChain
         {
             public IdentityRenderChain() : base(x => x) { }
-
-            public override Func<string> Status { get { return () => ""; } set { } }
         }
 
         private class IdentityRenderChainUi : RenderChainUi<IdentityRenderChain>

--- a/Extensions/Framework/RenderChain/ShaderCache.cs
+++ b/Extensions/Framework/RenderChain/ShaderCache.cs
@@ -224,7 +224,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IShader CompileShader(string shaderFileName, string profile = "ps_3_0", string entryPoint = "main", string macroDefinitions = null)
         {
             var result = Cache<IShader>.AddCompiled(shaderFileName,
-                string.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
+                String.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
                 () => Renderer.CompileShader(shaderFileName, entryPoint, profile, macroDefinitions),
                 Renderer.LoadShader);
 
@@ -235,7 +235,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IShader11 CompileShader11(string shaderFileName, string profile, string entryPoint = "main", string macroDefinitions = null)
         {
             var result = Cache<IShader11>.AddCompiled(shaderFileName,
-                string.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
+                String.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
                 () => Renderer.CompileShader11(shaderFileName, entryPoint, profile, macroDefinitions),
                 Renderer.LoadShader11);
 
@@ -246,7 +246,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IKernel CompileClKernel(string sourceFileName, string entryPoint, string options = null)
         {
             return Cache<IKernel>.AddCompiled(sourceFileName,
-                string.Format("\"{0}\" /E {1} /Opts {2}", GetRelative(sourceFileName), entryPoint, options),
+                String.Format("\"{0}\" /E {1} /Opts {2}", GetRelative(sourceFileName), entryPoint, options),
                 () => Renderer.CompileClKernel(sourceFileName, entryPoint, options),
                 null);
         }

--- a/Extensions/Framework/RenderChain/ShaderCache.cs
+++ b/Extensions/Framework/RenderChain/ShaderCache.cs
@@ -224,7 +224,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IShader CompileShader(string shaderFileName, string profile = "ps_3_0", string entryPoint = "main", string macroDefinitions = null)
         {
             var result = Cache<IShader>.AddCompiled(shaderFileName,
-                String.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
+                string.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
                 () => Renderer.CompileShader(shaderFileName, entryPoint, profile, macroDefinitions),
                 Renderer.LoadShader);
 
@@ -235,7 +235,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IShader11 CompileShader11(string shaderFileName, string profile, string entryPoint = "main", string macroDefinitions = null)
         {
             var result = Cache<IShader11>.AddCompiled(shaderFileName,
-                String.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
+                string.Format("\"{0}\" /E {1} /T {2} /D {3}", GetRelative(shaderFileName), entryPoint, profile, macroDefinitions),
                 () => Renderer.CompileShader11(shaderFileName, entryPoint, profile, macroDefinitions),
                 Renderer.LoadShader11);
 
@@ -246,7 +246,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static IKernel CompileClKernel(string sourceFileName, string entryPoint, string options = null)
         {
             return Cache<IKernel>.AddCompiled(sourceFileName,
-                String.Format("\"{0}\" /E {1} /Opts {2}", GetRelative(sourceFileName), entryPoint, options),
+                string.Format("\"{0}\" /E {1} /Opts {2}", GetRelative(sourceFileName), entryPoint, options),
                 () => Renderer.CompileClKernel(sourceFileName, entryPoint, options),
                 null);
         }

--- a/Extensions/Framework/Scripting/ScriptEngineUtilities.cs
+++ b/Extensions/Framework/Scripting/ScriptEngineUtilities.cs
@@ -326,7 +326,6 @@ namespace Mpdn.Extensions.Framework.Scripting
             {
                 m_Chain = chain;
                 Filter = input;
-                Status = () => string.Empty;
             }
 
             public Clip Add(RenderChain.RenderChain filter)
@@ -336,8 +335,6 @@ namespace Mpdn.Extensions.Framework.Scripting
                     throw new ArgumentNullException("filter");
                 }
                 Filter += filter;
-                var currentStatus = Status;
-                Status = () => string.Format("{0};{1}", currentStatus(), filter.Status());
                 
                 return this;
             }

--- a/Extensions/PlayerExtensions/DisplayChanger.NativeMethods.cs
+++ b/Extensions/PlayerExtensions/DisplayChanger.NativeMethods.cs
@@ -115,7 +115,7 @@ namespace Mpdn.Extensions.PlayerExtensions.DisplayChangerNativeMethods
         public const int DISP_CHANGE_RESTART = 1;
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        public static extern IntPtr PostMessage(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam);
+        public static extern IntPtr PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
         [DllImport("user32.dll", CharSet = CharSet.Ansi)]
         public static extern int EnumDisplaySettings(string lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);

--- a/Extensions/PlayerExtensions/Playlist.cs
+++ b/Extensions/PlayerExtensions/Playlist.cs
@@ -215,7 +215,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
                         }
 
                         int endChapter = int.Parse(s[2]);
-                        bool active = Boolean.Parse(s[3]);
+                        bool active = bool.Parse(s[3]);
                         string duration = s[4];
 
                         playList.Add(new PlaylistItem(filePath, skipChapters, endChapter, active, duration));

--- a/Extensions/PlayerExtensions/PlaylistForm.cs
+++ b/Extensions/PlayerExtensions/PlaylistForm.cs
@@ -595,7 +595,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
 
                     if (endChapterCell.Value != null && endChapterCell.Value.ToString() != string.Empty)
                     {
-                        var value = new string(endChapterCell.Value.ToString().Where(Char.IsDigit).ToArray());
+                        var value = new string(endChapterCell.Value.ToString().Where(char.IsDigit).ToArray());
 
                         if (CurrentItem != null && i == m_CurrentPlayIndex)
                         {
@@ -1128,7 +1128,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
                     else skipChapters.Add(int.Parse(s[1]));
                 }
                 int endChapter = int.Parse(s[2]);
-                bool active = Boolean.Parse(s[3]);
+                bool active = bool.Parse(s[3]);
                 string duration = s[4];
                 int playCount = int.Parse(s[5]);
 
@@ -1781,7 +1781,6 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
         private void PlaybackCompleted(object sender, EventArgs e)
         {
             if (Player.State == PlayerState.Closed) return;
-            if (CurrentItem == null) return;
             if (Media.Position == Media.Duration)
             {
                 CurrentItem.PlayCount++;

--- a/Extensions/RenderScripts/Hylian.Super-xBR.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Hylian.Super-xBR.ConfigDialog.cs
@@ -30,8 +30,8 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override void LoadSettings()
             {
-                EdgeStrengthSetter.Value = (Decimal)Settings.EdgeStrength;
-                SharpnessSetter.Value = (Decimal)Settings.Sharpness;
+                EdgeStrengthSetter.Value = (decimal)Settings.EdgeStrength;
+                SharpnessSetter.Value = (decimal)Settings.Sharpness;
                 FastBox.Checked = Settings.FastMethod;
                 ExtraPassBox.Checked = Settings.ThirdPass;
             }

--- a/Extensions/RenderScripts/Mpdn.Conditional.cs
+++ b/Extensions/RenderScripts/Mpdn.Conditional.cs
@@ -51,8 +51,6 @@ namespace Mpdn.Extensions.RenderScripts
                 if (!m_Engine.Evaluate(this, input, GetScript(), GetType().Name))
                     return input;
 
-                Status = () => Preset.Status();
-
                 return input + Preset;
             }
 

--- a/Extensions/RenderScripts/Mpdn.EwaChromaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaChromaScaler.cs
@@ -25,9 +25,9 @@ namespace Mpdn.Extensions.RenderScripts
     {
         public class EwaChromaScaler : EwaScaler, IChromaScaler
         {
-            public override string Active()
+            public override string Status
             {
-                return "EWA Chroma" + base.Active().Substring(3);
+                get { return "EWA Chroma" + base.Status.Substring(3); }
             }
 
             protected override string ShaderPath
@@ -63,8 +63,7 @@ namespace Mpdn.Extensions.RenderScripts
                 if (targetSize.Width < chromaSize.Width || targetSize.Height < chromaSize.Height)
                     return null;
 
-                var resizedLuma = lumaInput.SetSize(targetSize);
-                Status = this.ChromaScalerStatus(resizedLuma);
+                var resizedLuma = lumaInput.SetSize(targetSize, tagged: true);
 
                 return GetEwaFilter(shader, new[] { resizedLuma, chromaInput }).ConvertToRgb();
             }

--- a/Extensions/RenderScripts/Mpdn.EwaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaScaler.cs
@@ -64,9 +64,12 @@ namespace Mpdn.Extensions.RenderScripts
 
             #endregion
 
-            public override string Active()
+            public override string Status
             {
-                return string.Format("EWA {0}", m_Scaler.Name + TapCount.ToInt() + (AntiRingingEnabled ? "AR" : ""));
+                get
+                {
+                    return string.Format("EWA {0}", m_Scaler.Name + TapCount.ToInt() + (AntiRingingEnabled ? "AR" : ""));
+                }
             }
 
             protected override string ShaderPath

--- a/Extensions/RenderScripts/Mpdn.ImageProcessor.cs
+++ b/Extensions/RenderScripts/Mpdn.ImageProcessor.cs
@@ -56,15 +56,18 @@ namespace Mpdn.Extensions.RenderScripts
                 get { return ShaderDataFilePath; }
             }
 
-            public override string Active()
+            public override string Status
             {
-                var count = ShaderFileNames.Count();
-                if (count == 0) return string.Empty;
-                var result = count == 1
-                    ? Path.GetFileNameWithoutExtension(ShaderFileNames.First())
-                    : string.Format("{0}..{1}", Path.GetFileNameWithoutExtension(ShaderFileNames.First()),
-                        Path.GetFileNameWithoutExtension(ShaderFileNames.Last()));
-                return string.Format("ImageProc('{0}')", result);
+                get
+                {
+                    var count = ShaderFileNames.Count();
+                    if (count == 0) return string.Empty;
+                    var result = count == 1
+                        ? Path.GetFileNameWithoutExtension(ShaderFileNames.First())
+                        : string.Format("{0}..{1}", Path.GetFileNameWithoutExtension(ShaderFileNames.First()),
+                            Path.GetFileNameWithoutExtension(ShaderFileNames.Last()));
+                    return string.Format("ImageProc('{0}')", result);
+                }
             }
 
             protected override IFilter CreateFilter(IFilter input)

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
@@ -53,10 +53,13 @@ namespace Mpdn.Extensions.RenderScripts
             };
             private static readonly int[] s_NeuronCount = { 16, 32, 64, 128, 256 };
 
-            public override string Active()
+            public override string Status
             {
-                return string.Format("{0} {1}/{2}", base.Active(), s_NeuronCount[(int)Neurons1],
-                    s_NeuronCount[(int)Neurons2]);
+                get
+                {
+                    return string.Format("{0} {1}/{2}", base.Status, s_NeuronCount[(int) Neurons1],
+                        s_NeuronCount[(int) Neurons2]);
+                }
             }
 
             public override void Reset()

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
@@ -142,12 +142,13 @@ namespace Mpdn.Extensions.RenderScripts
             };
             private static readonly int[] s_NeuronCount = { 16, 32, 64, 128, 256 };
 
-            public override string Active()
+            public override string Status
             {
-                var status = string.Format("{0} {1}/{2}", base.Active(), s_NeuronCount[(int) Neurons1],
-                    s_NeuronCount[(int) Neurons2]);
-
-                return status.AppendChromaStatus(ChromaScaler, Renderer.ChromaUpscaler);
+                get
+                {
+                    return string.Format("{0} {1}/{2}", base.Status, s_NeuronCount[(int) Neurons1],
+                        s_NeuronCount[(int) Neurons2]);
+                }
             }
 
             public override void Reset()

--- a/Extensions/RenderScripts/Mpdn.Resizer.cs
+++ b/Extensions/RenderScripts/Mpdn.Resizer.cs
@@ -70,18 +70,8 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override IFilter CreateFilter(IFilter input)
             {
-                var result = input.SetSize(GetOutputSize());
-                Status = () => ResizerStatus(result);
-                return result;
-            }
-
-            public string ResizerStatus(IFilter result)
-            {
-                var resizer = result as ResizeFilter;
-                if (resizer != null)
-                    return resizer.Status();
-
-                return "";
+                return input.SetSize(GetOutputSize(), tagged: true)
+                    .Tagged(new TemporaryTag("Resizer"));
             }
 
             #region Size Calculation

--- a/Extensions/RenderScripts/Mpdn.ScriptChain.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptChain.cs
@@ -26,18 +26,7 @@ namespace Mpdn.Extensions.RenderScripts
         {
             protected override IFilter CreateFilter(IFilter input)
             {
-                Status = Active;
                 return Options.Aggregate(input, (result, chain) => result + chain);
-            }
-
-            public override string Active()
-            {
-                var statuses = Options
-                    .Select(chain => chain.Status())
-                    .Where(str => !string.IsNullOrEmpty(str))
-                    .ToArray();
-
-                return string.Join("; ", statuses);
             }
         }
 

--- a/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptGroup.cs
@@ -102,12 +102,6 @@ namespace Mpdn.Extensions.RenderScripts
                 base.Reset();
             }
 
-            public override Func<string> Status
-            {
-                get { return SelectedOption != null ? SelectedOption.Status : Inactive; }
-                set { if (SelectedOption != null) SelectedOption.Status = value; }
-            }
-
             #region Hotkey Handling
 
             private readonly Guid m_HotkeyGuid;

--- a/Extensions/RenderScripts/Mpdn.ScriptedRenderChain.cs
+++ b/Extensions/RenderScripts/Mpdn.ScriptedRenderChain.cs
@@ -75,7 +75,6 @@ namespace Mpdn.Extensions.RenderScripts
                 if (clip == null)
                     return null;
 
-                Status = clip.Status;
                 return clip.Filter;
             }
 

--- a/Extensions/RenderScripts/Shiandow.Bilateral.cs
+++ b/Extensions/RenderScripts/Shiandow.Bilateral.cs
@@ -46,8 +46,7 @@ namespace Mpdn.Extensions.RenderScripts
                 if (targetSize.Width < chromaSize.Width || targetSize.Height < chromaSize.Height)
                     return null;
 
-                var resizedLuma = lumaInput.SetSize(targetSize);
-                Status = this.ChromaScalerStatus(resizedLuma);
+                var resizedLuma = lumaInput.SetSize(targetSize, tagged: true);
 
                 return new ShaderFilter(crossBilateral, resizedLuma, chromaInput).ConvertToRgb();
             }

--- a/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
@@ -103,8 +103,7 @@ namespace Mpdn.Extensions.RenderScripts
                 Vector2 offset = chromaOffset + new Vector2(0.5f, 0.5f);
                 var chromaShader = CompileShader("Chroma.hlsl").Configure(arguments: new[] { B, C, offset[0], offset[1] });
 
-                var resizedLuma = lumaInput.SetSize(targetSize);
-                Status = this.ChromaScalerStatus(resizedLuma);
+                var resizedLuma = lumaInput.SetSize(targetSize, tagged: true);
 
                 return new ShaderFilter(chromaShader, resizedLuma, chromaInput).ConvertToRgb();
             }

--- a/Extensions/RenderScripts/Shiandow.Chroma.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Shiandow.Chroma.ConfigDialog.cs
@@ -42,8 +42,8 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override void LoadSettings()
             {
-                BSetter.Value = (Decimal) Settings.B;
-                CSetter.Value = (Decimal) Settings.C;
+                BSetter.Value = (decimal) Settings.B;
+                CSetter.Value = (decimal) Settings.C;
                 PresetBox.SelectedIndex = (int) Settings.Preset;
             }
 
@@ -69,8 +69,8 @@ namespace Mpdn.Extensions.RenderScripts
                     return;
 
                 m_SettingPreset = true;
-                BSetter.Value = (Decimal) BicubicChroma.B_CONST[index];
-                CSetter.Value = (Decimal) BicubicChroma.C_CONST[index];
+                BSetter.Value = (decimal) BicubicChroma.B_CONST[index];
+                CSetter.Value = (decimal) BicubicChroma.C_CONST[index];
                 m_SettingPreset = false;
             }
         }

--- a/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.ConfigDialog.cs
@@ -30,8 +30,8 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override void LoadSettings()
             {
-                MaxBitdepthSetter.Value = (Decimal)Settings.maxbitdepth;
-                PowerSetter.Value = (Decimal)Settings.power;
+                MaxBitdepthSetter.Value = (decimal)Settings.maxbitdepth;
+                PowerSetter.Value = (decimal)Settings.power;
                 GrainBox.Checked = Settings.grain;
 
                 UpdateGui();

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Chroma.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Chroma.Scaler.cs
@@ -52,10 +52,13 @@ namespace Mpdn.Extensions.RenderScripts
             private Nnedi3Filter m_VFilter1;
             private Nnedi3Filter m_VFilter2;
 
-            public override string Active()
+            public override string Status
             {
-                return string.Format("{0} {1}/{2}", base.Active(), s_NeuronCount[(int)Neurons1],
-                    s_NeuronCount[(int)Neurons2]);
+                get
+                {
+                    return string.Format("{0} {1}/{2}", base.Status, s_NeuronCount[(int) Neurons1],
+                        s_NeuronCount[(int) Neurons2]);
+                }
             }
 
             public override void Reset()

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -65,12 +65,13 @@ namespace Mpdn.Extensions.RenderScripts
                 }
             }
 
-            public override string Active()
+            public override string Status
             {
-                var status = string.Format("{0} {1}/{2}", base.Active(), s_NeuronCount[(int) Neurons1],
-                    s_NeuronCount[(int) Neurons2]);
-
-                return status.AppendChromaStatus(ChromaScaler, Renderer.ChromaUpscaler);
+                get
+                {
+                    return string.Format("{0} {1}/{2}", base.Status, s_NeuronCount[(int) Neurons1],
+                        s_NeuronCount[(int) Neurons2]);
+                }
             }
 
             public override void Reset()

--- a/Extensions/RenderScripts/Shiandow.SuperChromaRes.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperChromaRes.ConfigDialog.cs
@@ -30,9 +30,9 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override void LoadSettings()
             {
-                PassesSetter.Value = (Decimal)Settings.Passes;
-                StrengthSetter.Value = (Decimal)Settings.Strength;
-                SoftnessSetter.Value = (Decimal)Settings.Softness;
+                PassesSetter.Value = (decimal)Settings.Passes;
+                StrengthSetter.Value = (decimal)Settings.Strength;
+                SoftnessSetter.Value = (decimal)Settings.Softness;
                 PrescalerBox.Checked = Settings.Prescaler;
             }
 

--- a/Extensions/RenderScripts/Shiandow.SuperRes.ConfigDialog.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.ConfigDialog.cs
@@ -47,8 +47,8 @@ namespace Mpdn.Extensions.RenderScripts
                 PrescalerBox.SelectedIndex = Settings.SelectedIndex;
 
                 PassesSetter.Value = Settings.Passes;
-                StrengthSetter.Value = (Decimal)Settings.Strength;
-                SoftnessSetter.Value = (Decimal)Settings.Softness;
+                StrengthSetter.Value = (decimal)Settings.Strength;
+                SoftnessSetter.Value = (decimal)Settings.Softness;
 
                 HQBox.Checked = Settings.HQdownscaling;
                 

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -97,11 +97,9 @@ namespace Mpdn.Extensions.RenderScripts
             #region Status
 
             // Revert ScriptGroups changes to Status
-            public override Func<string> Status { get; set; }
-
-            public override string Active()
+            public override string Status
             {
-                return base.Active().AppendSubStatus(SelectedOption.Status());
+                get { return "SuperRes"; }
             }
 
             #endregion

--- a/Mpdn.Extensions.Framework.csproj
+++ b/Mpdn.Extensions.Framework.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Extensions\Framework\RenderChain\Filter.cs" />
     <Compile Include="Extensions\Framework\RenderChain\Filter.Shaders.cs" />
     <Compile Include="Extensions\Framework\RenderChain\Filter.Sources.cs" />
+    <Compile Include="Extensions\Framework\RenderChain\Filter.Tag.cs" />
     <Compile Include="Extensions\Framework\RenderChain\Filter.Text.cs" />
     <Compile Include="Extensions\Framework\RenderChain\Filter.Utilities.cs" />
     <Compile Include="Extensions\Framework\RenderChain\RenderChain.cs" />


### PR DESCRIPTION
Keep track of processes by adding tags to the filters.

Tags ignore optimizations, but instead keep track of which filters are used to create a filter.
This avoids problems where a tag could be ignored if the corresponding filter was skipped (as a result of using "ConvertToRgb" or similar).
This behaviour can also be influenced manually (although this can create loops, which cause crashes, so be careful).

In some rare cases ignoring optimizations could show a script is active, even if it isn't technically having any effect.
Usually those cases can be avoided, and are preferrable to the alternative (not displaying something which *is* having an effect).

By default an output is only tagged once (to avoid having 'meta' renderchains show up in the status).
This also makes it possible to override default behaviour.
Care should be taken if the final output of a renderchain is generated by an other renderchain (which never happens except for meta renderchains at the moment).

Tags automatically keep track of subprocesses of a renderchain (things like NNEDI3's chroma scaler, or SuperRes's prescaler).
To make it possible to distinguish between scripts applies sequentially and parallel a 'bottom' tag was added.
This tag which represents the original source of data, but isn't displayed in the status.

Tags remember the entire data flow so it's possible to keep track which input is responsible for which output.
A particular example of this is the special ChromaScalerTag which automatically separates processing done to scale the luma from processing done to scale the chroma and displays the status accordingly.

Tags should continue working no matter how complicated the chain becomes, but the resulting text could be hard to read in more complicated cases.
However unlike the previous system it's reasonably easy to modify the way the tag system is displayed.