### PR TITLE
[Readme] update wiki url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ MPDN Extensions
 
 MPDN project page - http://www.zachsaw.com/mpdn/  
 MPDN support page on Doom9.org - http://forum.doom9.org/showthread.php?t=171120  
-MPDN Extensions Wiki - https://github.com/zachsaw/MPDN_Extensions/wiki/MPDN-Extensions-Wiki---Home  
+MPDN Extensions Wiki - https://github.com/zachsaw/MPDN_Extensions/wiki
 
 <H3>Developers</H3>
 * Zachs


### PR DESCRIPTION
The wiki home page had been renamed to make it the 'default' wiki page (which is apparently only possible by changing the title to "home").