### PR TITLE
[Playlist] Don't try to play the next in directory if the file doesn't exist

### DIFF
--- a/Extensions/PlayerExtensions/Playlist.cs
+++ b/Extensions/PlayerExtensions/Playlist.cs
@@ -289,6 +289,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
         private void PlayNextInFolder()
         {
             if (Media.Position != Media.Duration) return;
+            if (!File.Exists(Media.FilePath)) return;
             m_Form.PlayNextFileInDirectory();
         }
 

--- a/Extensions/PlayerExtensions/PlaylistForm.cs
+++ b/Extensions/PlayerExtensions/PlaylistForm.cs
@@ -1115,6 +1115,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
                 switch (m_PlayListUi.Settings.AfterPlaybackOpt)
                 {
                     case AfterPlaybackSettingsOpt.PlayNextFileInFolder:
+                        if (!File.Exists(Media.FilePath)) return;
                         LoadInBackground(GetNextFileInDirectory());
                         break;
                     case AfterPlaybackSettingsOpt.RepeatPlaylist:


### PR DESCRIPTION
Small fixup.
Fixes crashing when trying to load the next file in directory if we're playing an URL.