### PR TITLE
Remove extra NotifyPlaylistChanged event from Playlist

### DIFF
--- a/Extensions/PlayerExtensions/PlaylistForm.cs
+++ b/Extensions/PlayerExtensions/PlaylistForm.cs
@@ -2417,7 +2417,7 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
                 if (destinationRow == -1 || destinationRow >= Playlist.Count) return;
                 var playItem = Playlist.ElementAt(m_DragRowIndex);
                 Playlist.RemoveAt(m_DragRowIndex);
-                NotifyPlaylistChanged();
+                //NotifyPlaylistChanged();
                 Playlist.Insert(destinationRow, playItem);
                 PopulatePlaylist();
                 dgv_PlayList.CurrentCell = dgv_PlayList.Rows[destinationRow].Cells[m_TitleCellIndex];


### PR DESCRIPTION
Remove extra NotifyPlaylistChanged event from Playlist (already called in Populatelaylist) that causes remote to receive multiple playlist changed events when rearranging the playlist.
This causes the remote to sometime show too many copies of a file as it is trying to do rearrangements while also trying to handle the next request.