### PR TITLE
Change HTTP to HTTPS for the UpdateChecker MPDN repo

### DIFF
--- a/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.PlayerExtension.cs
+++ b/Extensions/PlayerExtensions/UpdateChecker/UpdateChecker.PlayerExtension.cs
@@ -208,7 +208,7 @@ namespace Mpdn.Extensions.PlayerExtensions.UpdateChecker
 
     public class UpdateChecker
     {
-        public static readonly string MpdnRepoUrl = "http://mpdn.zachsaw.com/";
+        public static readonly string MpdnRepoUrl = "https://mpdn.zachsaw.com/";
         public static readonly string LatestFolderUrl = string.Format("{0}Latest/", MpdnRepoUrl);
         protected readonly UpdateCheckerSettings Settings;
         protected readonly WebClient WebClient = new WebClient();


### PR DESCRIPTION
I'm using [let's encrypt](https://letsencrypt.org/) to automatically generate and update certificate for most of my website. I applied the same for MPDN.