### PR TITLE
[Fix] Stack overflow on failed chromascaler resize.

### DIFF
--- a/Extensions/Framework/RenderChain/TextureFilter/Chroma.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Chroma.cs
@@ -63,10 +63,10 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
         public TextureSize TargetSize { get; private set; }
         public Vector2 ChromaOffset { get; private set; }
 
-        protected readonly CompositionFilter Fallback;
+        protected readonly ICompositionFilter Fallback;
         protected readonly IChromaScaler ChromaScaler;
 
-        public CompositionFilter(ITextureFilter lumaInput, ITextureFilter chromaInput, IChromaScaler chromaScaler, TextureSize? targetSize = null, Vector2? chromaOffset = null, CompositionFilter fallback = null)
+        public CompositionFilter(ITextureFilter lumaInput, ITextureFilter chromaInput, IChromaScaler chromaScaler, TextureSize? targetSize = null, Vector2? chromaOffset = null, ICompositionFilter fallback = null)
         {
             if (lumaInput == null)
                 throw new ArgumentNullException("lumaInput");
@@ -87,9 +87,9 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
             return Rebuild(targetSize: outputSize);
         }
 
-        public ICompositionFilter Rebuild(IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null)
+        public ICompositionFilter Rebuild(IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null, ICompositionFilter fallback = null)
         {
-            return new CompositionFilter(Luma, Chroma, chromaScaler ?? ChromaScaler, targetSize ?? TargetSize, chromaOffset ?? ChromaOffset, this)
+            return new CompositionFilter(Luma, Chroma, chromaScaler ?? ChromaScaler, targetSize ?? TargetSize, chromaOffset ?? ChromaOffset, fallback ?? Fallback)
                 .Tagged(Tag);
         }
 

--- a/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
@@ -38,7 +38,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
         TextureSize TargetSize { get; }
         Vector2 ChromaOffset { get; }
 
-        ICompositionFilter Rebuild(IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null);
+        ICompositionFilter Rebuild(IChromaScaler chromaScaler = null, TextureSize? targetSize = null, Vector2? chromaOffset = null, ICompositionFilter fallback = null);
     }
 
     public interface IShaderFilterSettings<T>
@@ -260,7 +260,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
             return filter.SetSize(filter.Output.Size, true);
         }
 
-        public static ITextureFilter SetSize(this ITextureFilter<ITexture2D> filter, TextureSize size, bool tagged = false)
+        public static ITextureFilter SetSize(this IFilter<ITextureOutput<ITexture2D>> filter, TextureSize size, bool tagged = false)
         {
             var resizeable = (filter as IResizeableFilter) ?? new ResizeFilter(filter);
             if (tagged)
@@ -408,7 +408,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
                 return input;
 
             return compositionFilter
-                .Rebuild(scaler)
+                .Rebuild(scaler, fallback: compositionFilter)
                 .Tagged(new ChromaScalerTag(compositionFilter.Chroma, scaler.Description));
         }
     }


### PR DESCRIPTION
Chroma scaler failed, calling "SetSize' on the fallback would make an
identical chroma scaler, which would also fail etc.

To prevent this fallback should only be changed manually, when
appropriate.