### PR TITLE
[Fix] Stack overflow caused by circular tag reference.

### DIFF
--- a/Extensions/Framework/RenderChain/TextureFilter/Chroma.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Chroma.cs
@@ -102,9 +102,12 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
 
         protected override IFilter<ITextureOutput<ITexture2D>> Optimize()
         {
-            return (ChromaScaler.CreateChromaFilter(Luma, Chroma, TargetSize, ChromaOffset) ?? Fallback)
+            var Result = ChromaScaler.CreateChromaFilter(Luma, Chroma, TargetSize, ChromaOffset);
+            if (Result != null)
+                Result.Tag.AddPrefix(Tag);
+
+            return (Result ?? Fallback)
                 .SetSize(TargetSize, tagged: true)
-                .PrefixTagTo(Tag)
                 .Compile();
         }
 


### PR DESCRIPTION
Tag system keeps creating problems, might be better to replace it entirely.