### PR TITLE
Minor fixup and add OSD config settings

### DIFF
--- a/Extensions/PlayerExtensions/OnScreenDisplay.ConfigDialog.Designer.cs
+++ b/Extensions/PlayerExtensions/OnScreenDisplay.ConfigDialog.Designer.cs
@@ -1,0 +1,123 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+namespace Mpdn.Extensions.PlayerExtensions
+{
+    partial class OnScreenDisplayConfigDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.cb_enableOSD = new System.Windows.Forms.CheckBox();
+            this.btn_save = new System.Windows.Forms.Button();
+            this.btn_cancel = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // cb_enableOSD
+            // 
+            this.cb_enableOSD.AutoSize = true;
+            this.cb_enableOSD.Location = new System.Drawing.Point(12, 20);
+            this.cb_enableOSD.Name = "cb_enableOSD";
+            this.cb_enableOSD.Size = new System.Drawing.Size(154, 17);
+            this.cb_enableOSD.TabIndex = 0;
+            this.cb_enableOSD.Text = "Enable On-Screen Display*";
+            this.cb_enableOSD.UseVisualStyleBackColor = true;
+            // 
+            // btn_save
+            // 
+            this.btn_save.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.btn_save.Location = new System.Drawing.Point(178, 57);
+            this.btn_save.Name = "btn_save";
+            this.btn_save.Size = new System.Drawing.Size(75, 23);
+            this.btn_save.TabIndex = 1;
+            this.btn_save.Text = "Save";
+            this.btn_save.UseVisualStyleBackColor = true;
+            this.btn_save.Click += new System.EventHandler(this.btn_save_Click);
+            // 
+            // btn_cancel
+            // 
+            this.btn_cancel.Location = new System.Drawing.Point(259, 57);
+            this.btn_cancel.Name = "btn_cancel";
+            this.btn_cancel.Size = new System.Drawing.Size(75, 23);
+            this.btn_cancel.TabIndex = 2;
+            this.btn_cancel.Text = "Cancel";
+            this.btn_cancel.UseVisualStyleBackColor = true;
+            this.btn_cancel.Click += new System.EventHandler(this.btn_cancel_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.ForeColor = System.Drawing.SystemColors.ButtonShadow;
+            this.label1.Location = new System.Drawing.Point(12, 62);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(92, 13);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "* requires a restart";
+            // 
+            // OnScreenDisplayConfigDialog
+            // 
+            this.AcceptButton = this.btn_save;
+            this.ClientSize = new System.Drawing.Size(346, 92);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.btn_cancel);
+            this.Controls.Add(this.btn_save);
+            this.Controls.Add(this.cb_enableOSD);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "OnScreenDisplayConfigDialog";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "On-Screen Display Settings";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button btn_save;
+        private System.Windows.Forms.Button btn_cancel;
+        private System.Windows.Forms.CheckBox cb_enableOSD;
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/Extensions/PlayerExtensions/OnScreenDisplay.ConfigDialog.cs
+++ b/Extensions/PlayerExtensions/OnScreenDisplay.ConfigDialog.cs
@@ -1,0 +1,53 @@
+﻿// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+// 
+
+using Mpdn.Extensions.Framework.Config;
+
+namespace Mpdn.Extensions.PlayerExtensions
+{
+    public partial class OnScreenDisplayConfigDialog : OnScreenDisplayConfigBase
+    {
+        public OnScreenDisplayConfigDialog()
+        {
+            InitializeComponent();
+        }
+
+        protected override void LoadSettings()
+        {
+            cb_enableOSD.Checked = Settings.EnableOnScreenDisplay;
+        }
+
+        protected override void SaveSettings()
+        {
+            Settings.EnableOnScreenDisplay = cb_enableOSD.Checked;
+        }
+
+        private void btn_save_Click(object sender, System.EventArgs e)
+        {
+            SaveSettings();
+        }
+
+        private void btn_cancel_Click(object sender, System.EventArgs e)
+        {
+            Close();
+        }
+    }
+
+    public class OnScreenDisplayConfigBase : ScriptConfigDialog<OnScreenDisplaySettings>
+    {
+    }
+}

--- a/Mpdn.Extensions.csproj
+++ b/Mpdn.Extensions.csproj
@@ -140,6 +140,12 @@
     <Compile Include="Extensions\PlayerExtensions\CustomSourceFilter.cs" />
     <Compile Include="Extensions\PlayerExtensions\DvdSourceProvider.cs" />
     <Compile Include="Extensions\PlayerExtensions\DynamicDirectShowFilter.cs" />
+    <Compile Include="Extensions\PlayerExtensions\OnScreenDisplay.ConfigDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Extensions\PlayerExtensions\OnScreenDisplay.ConfigDialog.Designer.cs">
+      <DependentUpon>OnScreenDisplay.ConfigDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="Extensions\PlayerExtensions\OnScreenDisplay.cs" />
     <Compile Include="Extensions\PlayerExtensions\RarFileSourceProvider.cs" />
     <Compile Include="Extensions\PlayerExtensions\YouTubeSourceProvider.cs" />


### PR DESCRIPTION
The OSD always stayed on-screen because the `MouseMove` event keeps firing if the pointer is visible on the frame even if you don't move your mouse. This fixes that issue. I've also added the ability to enable or disable the OSD through the settings. By default it is disabled.

~~I also tried to make this not dependent on the Playlist, but apparently a lot of extensions rely on it, so I guess it doesn't really matter.~~ (Nvm, its out of scope for this PR)