### PR TITLE
Framework Changes + DebandExperimental update + Audio Crossfeed filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ ModelManifest.xml
 
 # MPDN
 MPDN/
+
+# Ignore Visual Studio temp files
+.vs/

--- a/Examples/AudioScripts/Example.Gargle.cs
+++ b/Examples/AudioScripts/Example.Gargle.cs
@@ -22,17 +22,12 @@ namespace Mpdn.Examples.AudioScripts
 {
     namespace Example
     {
-        public class Gargle : AudioFilter
+        public class Gargle : CpuAudioFilter
         {
             private const int GARGLE_RATE = 5;
             private const int SHAPE = 0; // 0=Triangle, 1=Sqaure
 
             private int m_Phase;
-
-            protected override bool CpuOnly
-            {
-                get { return true; }
-            }
 
             protected override void Process(float[,] samples, short channels, int sampleCount)
             {

--- a/Examples/AudioScripts/Example.Silencer.cs
+++ b/Examples/AudioScripts/Example.Silencer.cs
@@ -22,14 +22,9 @@ namespace Mpdn.Examples.AudioScripts
 {
     namespace Example
     {
-        public class Silencer : AudioFilter
+        public class Silencer : CpuAudioFilter
         {
             private const int CHANNEL_TO_SILENT = 0;
-
-            protected override bool CpuOnly
-            {
-                get { return true; }
-            }
 
             protected override void Process(float[,] samples, short channels, int sampleCount)
             {

--- a/Examples/RenderScripts/Example.DirectCompute.cs
+++ b/Examples/RenderScripts/Example.DirectCompute.cs
@@ -44,8 +44,8 @@ namespace Mpdn.Extensions.RenderScripts
                 var blueTint =
                     CompileShader11("BlueTintDirectCompute.hlsl", "cs_5_0")
                         .Configure(arguments: new[] {0.25f, 0.5f, 0.75f});
-                var width = sourceFilter.Output.Size.Width;
-                var height = sourceFilter.Output.Size.Height;
+                var width = sourceFilter.Size().Width;
+                var height = sourceFilter.Size().Height;
                 return new DirectComputeFilter(blueTint, width/32 + 1, height/32 + 1, 1, sourceFilter);
             }
         }

--- a/Examples/RenderScripts/Example.OpenCl.cs
+++ b/Examples/RenderScripts/Example.OpenCl.cs
@@ -46,7 +46,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var blueTint = CompileClKernel("BlueTint.cl", "BlueTint")
                     .Configure(arguments: new[] {0.25f, 0.5f, 0.75f});
 
-                var outputSize = sourceFilter.Output.Size;
+                var outputSize = sourceFilter.Size();
                 return new ClKernelFilter(blueTint, new[] {outputSize.Width, outputSize.Height}, sourceFilter);
             }
         }

--- a/Extensions/AudioScripts/Mpdn.Reclock.cs
+++ b/Extensions/AudioScripts/Mpdn.Reclock.cs
@@ -23,7 +23,7 @@ namespace Mpdn.Extensions.AudioScripts
 {
     namespace Mpdn
     {
-        public class Reclock : AudioFilter
+        public class Reclock : AudioFilterBase
         {
             private const double MAX_PERCENT_ADJUST = 3; // automatically reclock if the difference is less than 3%
             private const double SANEAR_OVERSHOOT = 5;
@@ -41,7 +41,7 @@ namespace Mpdn.Extensions.AudioScripts
             private int m_SampleIndex = -8*RATIO_ADJUST_INTERVAL;
             private double m_Ratio = 1;
 
-            public override bool Process(IAudioOutput input, IAudioOutput output)
+            protected override bool Process(IAudioOutput input, IAudioOutput output)
             {
                 if (!CalculateRatio(input))
                 {
@@ -156,11 +156,6 @@ namespace Mpdn.Extensions.AudioScripts
                 Player.StateChanged -= PlayerStateChanged;
 
                 base.Dispose(disposing);
-            }
-
-            protected override void Process(float[,] samples, short channels, int sampleCount)
-            {
-                throw new InvalidOperationException();
             }
 
             private void PlayerStateChanged(object sender, PlayerStateEventArgs e)

--- a/Extensions/AudioScripts/Shiandow.Crossfeed.cs
+++ b/Extensions/AudioScripts/Shiandow.Crossfeed.cs
@@ -1,0 +1,191 @@
+﻿// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+
+using System;
+using Mpdn.Extensions.Framework.AudioChain;
+
+namespace Mpdn.Extensions.AudioScripts.Shiandow
+{
+    public class Crossfeed : CpuAudioFilter
+    {
+        protected override void Process(float[,] samples, short channels, int sampleCount)
+        {
+            if (channels != 2)
+                return;
+
+            Apply(samples, Output.Format.nSamplesPerSec);
+        }
+        
+        const int crossfeedOrder = 16;
+        float[,] crossfeed = new float[2, crossfeedOrder];
+
+        const int echoOrder = 12;
+        float[,] echo = new float[2, echoOrder];
+
+        public void Apply(float[,] samples, int frequency)
+        {
+            int length = samples.GetLength(1);
+
+            float crossfeedDelay = 450f;
+            float echoDelay = 1200f;// crossfeedDelay * (float) (Math.PI / Math.Sqrt(2.0));
+
+            float crossfeedAttenuation = -3.5f;
+            float echoAttenuation = -8.0f;
+
+            float volume = (float) Math.Pow(10, crossfeedAttenuation / 10);
+            float a = (1000000 * (crossfeedOrder - 1)) / (crossfeedDelay * frequency);
+            float strength = (2 - a) / (2 + a);
+
+            for (int i = 0; i < length; i++)
+            {
+                float L = samples[0, i];
+                float R = samples[1, i];
+
+                float prevL = crossfeed[0, 0];
+                float prevR = crossfeed[1, 0];
+
+                crossfeed[0, 0] = L;
+                crossfeed[1, 0] = R;
+
+                // Bilinear transform of Laplace transform ((a + s)^-k) of gamma distribution (x^(k-1) e^(-ax))
+                for (int j = 1; j < crossfeedOrder; j++)
+                {
+                    L = (1 - strength) * (L + prevL) / 2.0f + strength * crossfeed[0, j];
+                    R = (1 - strength) * (R + prevR) / 2.0f + strength * crossfeed[1, j];
+
+                    prevL = crossfeed[0, j];
+                    prevR = crossfeed[1, j];
+
+                    crossfeed[0, j] = L;
+                    crossfeed[1, j] = R;
+                }
+
+                samples[0, i] = (samples[0, i] + volume * R) / (1 + volume);
+                samples[1, i] = (samples[1, i] + volume * L) / (1 + volume);
+            }
+
+            /*
+            //float spread = ((crossfeedDelay / crossfeedOrder) * frequency) / 1000000;
+            //float strength = (float) Math.Exp(-1 / spread);
+            float strength = crossfeedDelay * frequency / (crossfeedOrder * 1000000 + crossfeedDelay * frequency); // Correct delay (at 0 hz)
+
+            for (int i = 0; i < length; i++)
+            {
+                float L = samples[0, i];
+                float R = samples[1, i];
+
+                // Zero-Pole mapping ((1 - e^-a z^-1)^-k) of Laplace transform ((a + s)^-k) of gamma distribution (x^(k-1) e^(-ax))
+                for (int j = 0; j < crossfeedOrder; j++)
+                {
+                    L = (1 - strength) * L + strength * crossfeed[0, j];
+                    R = (1 - strength) * R + strength * crossfeed[1, j];
+
+                    crossfeed[0, j] = L;
+                    crossfeed[1, j] = R;
+                }
+
+                samples[0, i] = (samples[0, i] + volume * R) / (1 + volume);
+                samples[1, i] = (samples[1, i] + volume * L) / (1 + volume);
+            }*/
+
+            volume = (float) Math.Pow(10, echoAttenuation / 10);
+            a = (1000000 * (echoOrder - 1)) / (echoDelay * frequency);
+            strength = (2 - a) / (2 + a);
+
+            for (int i = 0; i < length; i++)
+            {
+                /*float L = (samples[0, i] + volume * echo[1, echoOrder - 1]);// / (1 + volume);
+                float R = (samples[1, i] + volume * echo[0, echoOrder - 1]);// / (1 + volume);
+
+                float prevL = echo[0, 0];
+                float prevR = echo[1, 0];
+
+                echo[0, 0] = L;
+                echo[1, 0] = R;
+
+                samples[0, i] = L * (1 - volume);
+                samples[1, i] = R * (1 - volume);*/
+
+                float L = samples[0, i];
+                float R = samples[1, i];
+
+                float prevL = echo[0, 0];
+                float prevR = echo[1, 0];
+
+                echo[0, 0] = L;
+                echo[1, 0] = R;
+
+                // Bilinear transform of Laplace transform ((a + s)^-k) of gamma distribution (x^(k-1) e^(-ax))
+                for (int j = 1; j < echoOrder; j++)
+                {
+                    L = (1 - strength) * (L + prevL) / 2.0f + strength * echo[0, j];
+                    R = (1 - strength) * (R + prevR) / 2.0f + strength * echo[1, j];
+
+                    prevL = echo[0, j];
+                    prevR = echo[1, j];
+
+                    echo[0, j] = L;
+                    echo[1, j] = R;
+                }
+
+                samples[0, i] = (samples[0, i] + volume * R) / (1 + volume);
+                samples[1, i] = (samples[1, i] + volume * L) / (1 + volume);
+            }
+
+            /*
+            float spread = ((echoDelay / echoOrder) * frequency) / 1000000;
+            strength = (float)Math.Exp(-1 / spread);
+            //strength = echoDelay * frequency / (echoOrder * 1000000 + echoDelay * frequency); // Correct delay (at 0 hz)
+
+            for (int i = 0; i < length; i++)
+            {
+                float L = (samples[0, i] + volume * echo[1, echoOrder - 1]);// / (1 + volume);
+                float R = (samples[1, i] + volume * echo[0, echoOrder - 1]);// / (1 + volume);
+
+                samples[0, i] = L * (1 - volume);
+                samples[1, i] = R * (1 - volume);
+
+                // Zero-Pole mapping ((1 - e^-a z^-1)^-k) of Laplace transform ((a + s)^-k) of gamma distribution (x^(k-1) e^(-ax))
+                for (int j = 0; j < echoOrder; j++)
+                {
+                    L = (1 - strength) * L + strength * echo[0, j];
+                    R = (1 - strength) * R + strength * echo[1, j];
+
+                    echo[0, j] = L;
+                    echo[1, j] = R;
+                }
+            }*/
+        }
+    }
+
+    public class CrossfeedUi : AudioChainUi<Crossfeed>
+    {
+        public override string Category { get { return "Crossfeed"; } }
+
+        public override ExtensionUiDescriptor Descriptor {
+            get
+            {
+                return new ExtensionUiDescriptor
+                {
+                    Guid = new Guid("C820B4A5-6721-4B08-BED5-BB9E1BBDE816"),
+                    Name = "Crossfeed",
+                    Description = "Adds crossfeed to audio.",
+                    Copyright = "By Shiandow (2017)"
+                };
+            }
+        }
+    }
+}

--- a/Extensions/Framework/Chain/ChainUi.cs
+++ b/Extensions/Framework/Chain/ChainUi.cs
@@ -32,7 +32,7 @@ namespace Mpdn.Extensions.Framework.Chain
         public static bool IsIdentity<T, TScript>(this IChainUi<T, TScript> chainUi)
             where TScript : class, IScript
         {
-            return chainUi is ChainUi<T, TScript>.IdentityRenderChainUi;
+            return chainUi == ChainUi<T, TScript>.IDENTITY;
         }
     }
 
@@ -41,12 +41,12 @@ namespace Mpdn.Extensions.Framework.Chain
     {
         public static readonly IChainUi<T, TScript> IDENTITY = new IdentityRenderChainUi();
 
-        public class IdentityRenderChain : StaticChain<T>
+        private class IdentityRenderChain : StaticChain<T>
         {
             public IdentityRenderChain() : base(x => x) { }
         }
 
-        public class IdentityRenderChainUi : ChainUi<T, TScript, IdentityRenderChain>
+        private class IdentityRenderChainUi : ChainUi<T, TScript, IdentityRenderChain>
         {
             public override string Category
             {

--- a/Extensions/Framework/Chain/Dialogs/ScriptChain.ConfigDialog.cs
+++ b/Extensions/Framework/Chain/Dialogs/ScriptChain.ConfigDialog.cs
@@ -19,7 +19,7 @@ using Mpdn.Extensions.Framework.Config;
 namespace Mpdn.Extensions.Framework.Chain.Dialogs
 {
     public partial class ScriptChainDialog<T, TScript> : ScriptChainDialogBase<T, TScript>
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     {
         public ScriptChainDialog()
@@ -39,7 +39,7 @@ namespace Mpdn.Extensions.Framework.Chain.Dialogs
     }
 
     public class ScriptChainDialogBase<T, TScript> : ScriptConfigDialog<ScriptChain<T, TScript>> 
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     { }
 }

--- a/Extensions/Framework/Chain/Dialogs/ScriptGroup.ConfigDialog.cs
+++ b/Extensions/Framework/Chain/Dialogs/ScriptGroup.ConfigDialog.cs
@@ -19,7 +19,7 @@ using Mpdn.Extensions.Framework.Config;
 namespace Mpdn.Extensions.Framework.Chain.Dialogs
 {
     public partial class ScriptGroupDialog<T, TScript> : ScriptGroupDialogBase<T, TScript>
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     {
         public ScriptGroupDialog()
@@ -43,7 +43,7 @@ namespace Mpdn.Extensions.Framework.Chain.Dialogs
     }
 
     public class ScriptGroupDialogBase<T, TScript> : ScriptConfigDialog<ScriptGroup<T,TScript>> 
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     { }
 }

--- a/Extensions/Framework/Chain/FilterChain.cs
+++ b/Extensions/Framework/Chain/FilterChain.cs
@@ -36,7 +36,7 @@ namespace Mpdn.Extensions.Framework.Chain
             if (output == input)
                 return input;
 
-            output.AddJunction(Description, input);
+            output.AddLabel(Description, start: input);
 
             return output;
         }

--- a/Extensions/Framework/Chain/FilterChainScript.cs
+++ b/Extensions/Framework/Chain/FilterChainScript.cs
@@ -36,7 +36,6 @@ namespace Mpdn.Extensions.Framework.Chain
 
         private IFilter<TOutput> m_SourceFilter;
         private IFilter<TOutput> m_Filter;
-        private ProcessTag m_Tag;
 
         private readonly Chain<TFilter> m_Chain;
 
@@ -68,14 +67,13 @@ namespace Mpdn.Extensions.Framework.Chain
                 m_Filter = m_Chain
                     .Process(input)
                     .Apply(FinalizeOutput)
-                    .GetTag(out m_Tag)
                     .Compile()
                     .InitializeFilter();
             }
             catch (Exception ex)
             {
-                m_Tag = ErrorMessage(ex);
                 m_Filter = HandleError(ex).Compile().InitializeFilter();
+                m_Filter.AddLabel(ErrorMessage(ex));
             }
             finally
             {
@@ -85,7 +83,7 @@ namespace Mpdn.Extensions.Framework.Chain
 
         private void UpdateStatus()
         {
-            Status = m_Tag != null ? m_Tag.CreateString() : "Status Invalid";
+            Status = m_Filter != null ? m_Filter.ProcessData.CreateString() : "Status Invalid";
         }
 
         public virtual bool Execute()

--- a/Extensions/Framework/Chain/Preset.cs
+++ b/Extensions/Framework/Chain/Preset.cs
@@ -47,9 +47,6 @@ namespace Mpdn.Extensions.Framework.Chain
             }
         }
 
-        [YAXAttributeForClass]
-        public Guid Guid { get; set; }
-
         public IChainUi<T, TScript> Script
         {
             get { return m_Script ?? ChainUi<T, TScript>.IDENTITY; }
@@ -65,11 +62,6 @@ namespace Mpdn.Extensions.Framework.Chain
         #endregion
 
         #region Chain implementation
-
-        public Preset()
-        {
-            Guid = Guid.NewGuid();
-        }
 
         public override T Process(T input)
         {
@@ -140,13 +132,6 @@ namespace Mpdn.Extensions.Framework.Chain
         public override string ToString()
         {
             return Name;
-        }
-
-        public static Preset<T, TScript> Make<S>(string name = null)
-            where S : IChainUi<T, TScript>, new()
-        {
-            var script = new S();
-            return new Preset<T, TScript> { Name = (name ?? script.Descriptor.Name), Script = script };
         }
     }
 }

--- a/Extensions/Framework/Chain/PresetCollections.cs
+++ b/Extensions/Framework/Chain/PresetCollections.cs
@@ -34,19 +34,19 @@ namespace Mpdn.Extensions.Framework.Chain
     }
 
     public class ScriptChain<T, TScript> : PresetCollection<T, TScript>
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     {
         public override T Process(T input)
         {
             var result = Options.Aggregate(input, (temp, chain) => temp + chain);
-            result.AddJunction(new StringTag(Description, 10), input);
+            result.AddLabel(Description, 10, input);
             return result;
         }
     }
 
     public class ScriptGroup<T, TScript> : PresetCollection<T, TScript>
-        where T : ITagged
+        where T : ITaggedProcess
         where TScript : class, IScript
     {
         #region Settings
@@ -79,7 +79,7 @@ namespace Mpdn.Extensions.Framework.Chain
         public override T Process(T input)
         {
             var result = (SelectedOption != null ? input + SelectedOption : input);
-            result.AddJunction(new StringTag(Description, 10), input);
+            result.AddLabel(Description, 10, input);
             return result;
         }
 

--- a/Extensions/Framework/Chain/PresetCollections.cs
+++ b/Extensions/Framework/Chain/PresetCollections.cs
@@ -63,23 +63,17 @@ namespace Mpdn.Extensions.Framework.Chain
             }
         }
 
-        [YAXDontSerialize]
-        public Preset<T, TScript> SelectedOption
+        public ScriptGroup()
         {
-            get { return Options != null ? Options.ElementAtOrDefault(SelectedIndex) ?? Options.LastOrDefault() : null; }
+            SelectedIndex = 0;
         }
 
         #endregion
 
-        public ScriptGroup()
+        [YAXDontSerialize]
+        public Preset<T, TScript> SelectedOption
         {
-            SelectedIndex = 0;
-            m_HotkeyGuid = Guid.NewGuid();
-        }
-
-        public int GetPresetIndex(Guid guid)
-        {
-            return Options.FindIndex(o => o.Guid == guid);
+            get { return Options != null ? Options.ElementAtOrDefault(SelectedIndex) ?? Options.LastOrDefault() : null; }
         }
 
         public override T Process(T input)
@@ -91,7 +85,7 @@ namespace Mpdn.Extensions.Framework.Chain
 
         #region Hotkey Handling
 
-        private readonly Guid m_HotkeyGuid;
+        private readonly Guid m_HotkeyGuid = Guid.NewGuid();
         private string m_Hotkey;
 
         private void RegisterHotkey()

--- a/Extensions/Framework/Config/ExtensionsUi.cs
+++ b/Extensions/Framework/Config/ExtensionsUi.cs
@@ -55,6 +55,7 @@ namespace Mpdn.Extensions.Framework.Config
             throw new NotImplementedException("SaveSettings undefined (should be overriden).");
         }
 
+        // Checks if DialogResult is OK, and if so saves the settings. Remember to set the DialogResult.
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             base.OnFormClosed(e);
@@ -70,6 +71,8 @@ namespace Mpdn.Extensions.Framework.Config
         where TSettings : class, new()
         where TDialog : IScriptConfigDialog<TSettings>, new()
     {
+        public event EventHandler<EventArgs> SettingsChanged;
+
         public int Version
         {
             get { return Extension.InterfaceVersion; }
@@ -127,8 +130,20 @@ namespace Mpdn.Extensions.Framework.Config
             using (var dialog = new TDialog())
             {
                 dialog.Setup(m_ScriptConfig.Config);
-                return dialog.ShowDialog(owner) == DialogResult.OK;
+                if (dialog.ShowDialog(owner) == DialogResult.OK)
+                {
+                    RaiseSettingsChanged();
+                    return true;
+                }
+
+                return false;
             }
+        }
+
+        protected virtual void RaiseSettingsChanged()
+        {
+            if (SettingsChanged != null)
+                SettingsChanged(this, new EventArgs());
         }
 
         #endregion

--- a/Extensions/Framework/Filter/Filter.Sources.cs
+++ b/Extensions/Framework/Filter/Filter.Sources.cs
@@ -23,9 +23,7 @@ namespace Mpdn.Extensions.Framework.Filter
     {
         public SourceFilter(TOutput output)
            : base(output)
-        {
-            Tag.Insert(ProcessTag.BOTTOM);
-        }
+        { }
 
         protected override void Render(IList<IFilterOutput> inputs) { }
     }

--- a/Extensions/Framework/Filter/Filter.cs
+++ b/Extensions/Framework/Filter/Filter.cs
@@ -28,7 +28,7 @@ namespace Mpdn.Extensions.Framework.Filter
         void EnableTag();
     }
 
-    public interface IFilter<out TOutput> : IDisposable, ITagged
+    public interface IFilter<out TOutput> : IDisposable, ITaggedProcess
         where TOutput : class, IFilterOutput
     {
         TOutput Output { get; }
@@ -93,7 +93,8 @@ namespace Mpdn.Extensions.Framework.Filter
 
             m_Output = output;
 
-            m_Tag = new EmptyTag();
+            m_ProcessData = new ProcessData();
+            ProcessData.AddInputs(InputFilters.Select(f => f.ProcessData));
         }
 
         protected abstract void Render(IList<TInput> inputs);
@@ -104,7 +105,6 @@ namespace Mpdn.Extensions.Framework.Filter
         private IFilter<TInput>[] m_CompiledFilters;
 
         private readonly TOutput m_Output;
-        private readonly ProcessTag m_Tag;
 
         private bool m_Updated;
         private bool m_Initialized;
@@ -120,8 +120,6 @@ namespace Mpdn.Extensions.Framework.Filter
                 return m_Output;
             }
         }
-
-        public ProcessTag Tag { get { return m_Tag; } }
 
         public int LastDependentIndex { get; private set; }
 
@@ -150,6 +148,7 @@ namespace Mpdn.Extensions.Framework.Filter
                 filter.Initialize(m_FilterIndex);
             }
 
+            ProcessData.Rank = m_FilterIndex;
             LastDependentIndex++;
             m_Initialized = true;
         }
@@ -169,10 +168,8 @@ namespace Mpdn.Extensions.Framework.Filter
                 .Select(x => x.Compile())
                 .ToArray();
 
-            var inputTag = new HubTag(m_InputFilters.Select(f => f.Tag).ToArray());
-            Tag.AddPrefix(inputTag);
-
             m_CompilationResult = Optimize();
+            ProcessData.AddInputs(new[] { m_CompilationResult.ProcessData });
             return m_CompilationResult;
         }
 
@@ -214,6 +211,14 @@ namespace Mpdn.Extensions.Framework.Filter
 
             Output.Deallocate();
         }
+
+        #endregion
+
+        #region ITaggedProcess Implementation
+
+        private readonly IProcessData m_ProcessData;
+
+        public IProcessData ProcessData { get { return m_ProcessData; } }
 
         #endregion
 

--- a/Extensions/Framework/Filter/Filter.cs
+++ b/Extensions/Framework/Filter/Filter.cs
@@ -224,6 +224,8 @@ namespace Mpdn.Extensions.Framework.Filter
 
         #region Resource Management
 
+        protected bool IsDisposed { get; private set; }
+
         ~Filter()
         {
             Dispose(false);
@@ -237,12 +239,14 @@ namespace Mpdn.Extensions.Framework.Filter
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposing)
+            if (!disposing || IsDisposed)
                 return;
 
             DisposeHelper.DisposeElements(m_InputFilters);
             DisposeHelper.DisposeElements(ref m_CompiledFilters);
             DisposeHelper.Dispose(m_Output);
+
+            IsDisposed = true;
         }
 
         #endregion

--- a/Extensions/Framework/RenderChain/ChromaScalerPreset.cs
+++ b/Extensions/Framework/RenderChain/ChromaScalerPreset.cs
@@ -1,16 +1,14 @@
 using Mpdn.Extensions.Framework.Chain;
 using Mpdn.Extensions.Framework.Config;
-using Mpdn.Extensions.Framework.RenderChain.TextureFilter;
 using Mpdn.RenderScript;
-using SharpDX;
 
 namespace Mpdn.Extensions.Framework.RenderChain
 {
     public class ChromaScalerPreset : Preset<ITextureFilter, IRenderScript>, IChromaScaler
     {
-        public ITextureFilter CreateChromaFilter(ITextureFilter lumaInput, ITextureFilter chromaInput, TextureSize targetSize, Vector2 chromaOffset)
+        public ITextureFilter ScaleChroma(ICompositionFilter composition)
         {
-            return new CompositionFilter(lumaInput, chromaInput, null, targetSize, chromaOffset) + Chain;
+            return composition + Chain;
         }
     }
 

--- a/Extensions/Framework/RenderChain/RenderChain.cs
+++ b/Extensions/Framework/RenderChain/RenderChain.cs
@@ -98,43 +98,6 @@ namespace Mpdn.Extensions.Framework.RenderChain
         }
 
         #endregion
-
-        #region Size Calculations
-
-        public bool IsDownscalingFrom(TextureSize size, TextureSize? targetSize = null)
-        {
-            var otherSize = targetSize ?? Renderer.TargetSize;
-            return otherSize.Width < size.Width && otherSize.Height < size.Height;
-        }
-
-        public bool IsNotScalingFrom(TextureSize size, TextureSize? targetSize = null)
-        {
-            var otherSize = targetSize ?? Renderer.TargetSize;
-            return size == otherSize;
-        }
-
-        public bool IsUpscalingFrom(TextureSize size, TextureSize? targetSize = null)
-        {
-            var otherSize = targetSize ?? Renderer.TargetSize;
-            return otherSize.Width > size.Width && otherSize.Height > size.Height;
-        }
-
-        public bool IsDownscalingFrom(ITextureFilter chain, TextureSize? targetSize = null)
-        {
-            return IsDownscalingFrom(chain.Output.Size, targetSize);
-        }
-
-        public bool IsNotScalingFrom(ITextureFilter chain, TextureSize? targetSize = null)
-        {
-            return IsNotScalingFrom(chain.Output.Size, targetSize);
-        }
-
-        public bool IsUpscalingFrom(ITextureFilter chain, TextureSize? targetSize = null)
-        {
-            return IsUpscalingFrom(chain.Output.Size, targetSize);
-        }
-
-        #endregion
     }
 
     public class RenderScriptChain : ScriptChain<ITextureFilter, IRenderScript> { }

--- a/Extensions/Framework/RenderChain/RenderChainScript.cs
+++ b/Extensions/Framework/RenderChain/RenderChainScript.cs
@@ -70,9 +70,9 @@ namespace Mpdn.Extensions.Framework.RenderChain
             DisposeHelper.Dispose(ref m_SourceFilter);
             m_SourceFilter = new VideoSourceFilter(this);
 
-            if (Renderer.InputFormat.IsYuv() 
+            if (Renderer.InputFormat.IsYuv()
                 && (Renderer.ChromaSize.Width < Renderer.LumaSize.Width || Renderer.ChromaSize.Height < Renderer.LumaSize.Height))
-                return new InternalChromaScaler(m_SourceFilter).MakeChromaFilter(new YSourceFilter(), new ChromaSourceFilter());
+                return new CompositionFilter(new YSourceFilter(), new ChromaSourceFilter(), fallback: m_SourceFilter);
 
             return m_SourceFilter;
         }

--- a/Extensions/Framework/RenderChain/Shader/ShaderFilter.cs
+++ b/Extensions/Framework/RenderChain/Shader/ShaderFilter.cs
@@ -31,7 +31,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.Shader
         { }
 
         public ShaderFilter(IShaderHandle shader, params IFilter<ITextureOutput<IBaseTexture>>[] inputFilters)
-            : base(shader.CalcSize(inputFilters.Select(f => f.Output.Size).ToList()), shader.OutputFormat, inputFilters)
+            : base(shader.CalcSize(inputFilters.Select(f => f.Size()).ToList()), shader.OutputFormat, inputFilters)
         {
             Shader = shader;
         }

--- a/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
@@ -237,6 +237,19 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
     #region Helpers
 
+    public static class TextureFilterHelper
+    {
+        public static TextureSize Size(this IBaseTextureFilter filter)
+        {
+            return filter.Output.Size;
+        }
+
+        public static TextureFormat Format(this IBaseTextureFilter filter)
+        {
+            return filter.Output.Format;
+        }
+    }
+
     public static class TransformationHelper
     {
         public static ITextureFilter ConvertToRgb(this ITextureFilter filter)
@@ -268,7 +281,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
         public static ITextureFilter Convolve(this ITextureFilter<ITexture2D> inputFilter, IScaler convolver, TextureChannels? channels = null, Vector2? offset = null, IScaler upscaler = null, IScaler downscaler = null, TextureFormat ? outputFormat = null)
         {
-            return new ResizeFilter(inputFilter, inputFilter.Output.Size, channels ?? TextureChannels.All, offset ?? Vector2.Zero, upscaler, downscaler, convolver, outputFormat);
+            return new ResizeFilter(inputFilter, inputFilter.Size(), channels ?? TextureChannels.All, offset ?? Vector2.Zero, upscaler, downscaler, convolver, outputFormat);
         }
 
         public static ITextureFilter SetSize(this IFilter<ITextureOutput<ITexture2D>> filter, TextureSize size, bool tagged = false)
@@ -287,7 +300,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
             private readonly Func<ITextureFilter, ITextureFilter> m_Transformation;
 
             public TransformedResizeableFilter(Func<ITextureFilter, ITextureFilter> transformation, IResizeableFilter inputFilter)
-                : base(inputFilter.Output.Size, inputFilter.Output.Format, inputFilter)
+                : base(inputFilter.Size(), inputFilter.Output.Format, inputFilter)
             {
                 m_InputFilter = inputFilter;
                 m_Transformation = transformation;
@@ -297,7 +310,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
             {
                 var result = m_Transformation(m_InputFilter);
 
-                if (m_InputFilter.Output.Size != result.Output.Size)
+                if (m_InputFilter.Size() != result.Size())
                     throw new InvalidOperationException("Transformation is not allowed to change the size.");
 
                 return m_Transformation(m_InputFilter);

--- a/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Interface.cs
@@ -286,9 +286,14 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
         public static ITextureFilter SetSize(this IFilter<ITextureOutput<ITexture2D>> filter, TextureSize size, bool tagged = false)
         {
+            ITextureFilter textureFilter;
+            if (filter.Size() == size && (textureFilter = filter as ITextureFilter) != null)
+                return textureFilter;
+
             var resizeable = (filter as IResizeableFilter) ?? new ResizeFilter(filter);
             if (tagged)
                 resizeable.EnableTag();
+
             return resizeable.SetSize(size);
         }
 

--- a/Extensions/Framework/RenderChain/TextureFilter/Shaders.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Shaders.cs
@@ -41,7 +41,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
                 throw new IndexOutOfRangeException(string.Format("No valid input filter at index {0}", settings.SizeIndex));
             }
 
-            return settings.Transform(inputFilters[settings.SizeIndex].Output.Size);
+            return settings.Transform(inputFilters[settings.SizeIndex].Size());
         }
 
         protected GenericShaderFilter(IShaderFilterSettings<T> settings, params IBaseTextureFilter[] inputFilters)

--- a/Extensions/Framework/RenderChain/TextureFilter/Shaders.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Shaders.cs
@@ -53,7 +53,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
                 .ToArray();
 
             Args = settings.Arguments;
-            Tag.Insert(new StringTag(settings.Name, 50));
+            this.AddLabel(settings.Name, 50);
         }
 
         protected abstract void SetTextureConstant(int index, IBaseTexture texture, bool linearSampling);

--- a/Extensions/Framework/RenderChain/TextureFilter/Sources.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Sources.cs
@@ -193,10 +193,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
 
         public TextureSourceFilter(ITextureOutput<TTexture> output)
             : base(output)
-        {
-            /* Don't connect to bottom label */
-            Tag.Purge(ProcessTag.BOTTOM);
-        }
+        { }
     }
     
     public sealed class NullFilter : SourceFilter<ITextureOutput<ITexture2D>>, ITextureFilter
@@ -226,7 +223,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
 
         public ITextureFilter GetYuv()
         {
-            return new VideoSourceFilter(m_TrueSource, Output.Size, true).Tagged(Tag);
+            return new VideoSourceFilter(m_TrueSource, Output.Size, true);
         }
 
         public ScriptInterfaceDescriptor Descriptor
@@ -234,14 +231,14 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
             get { return m_TrueSource.Descriptor; }
         }
 
-        public static void InsertScaleDescription(ProcessTag tag, TextureSize size)
+        public static IEnumerable<string> ScaleDescription(TextureSize size)
         {
             var chromaConvolver = Renderer.ChromaOffset.IsZero ? null : Renderer.ChromaUpscaler;
             var chromastatus = StatusHelpers.ScaleDescription(Renderer.ChromaSize, size, Renderer.ChromaUpscaler, Renderer.ChromaDownscaler, chromaConvolver);
             var lumastatus = StatusHelpers.ScaleDescription(Renderer.VideoSize, size, Renderer.LumaUpscaler, Renderer.LumaDownscaler);
 
-            tag.Insert(chromastatus.PrependToDescription("Chroma: "));
-            tag.Insert(lumastatus.PrependToDescription("Luma: "));
+            yield return chromastatus.PrependToDescription("Chroma: ");
+            yield return lumastatus.PrependToDescription("Luma: ");
         }
 
         public VideoSourceFilter(IRenderScript script) : this(new TrueSourceFilter(script)) { } 
@@ -278,7 +275,7 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
 
         public ITextureFilter SetSize(TextureSize outputSize)
         {
-            return new VideoSourceFilter(m_TrueSource, outputSize, m_WantYuv).Tagged(Tag);
+            return new VideoSourceFilter(m_TrueSource, outputSize, m_WantYuv);
         }
 
         private sealed class TrueSourceFilter : SourceFilter<ITextureOutput<ITexture2D>>, ITextureFilter
@@ -297,7 +294,8 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
             {
                 base.Initialize();
 
-                InsertScaleDescription(Tag, Output.Size);
+                foreach (var label in ScaleDescription(Output.Size))
+                    this.AddLabel(label);
             }
 
             public bool IsYuv()

--- a/Extensions/Framework/RenderChain/TextureFilter/Transformation.cs
+++ b/Extensions/Framework/RenderChain/TextureFilter/Transformation.cs
@@ -185,14 +185,14 @@ namespace Mpdn.Extensions.Framework.RenderChain.TextureFilter
         {
             var result = new ResizeFilter(InputFilter, targetSize, m_Channels, m_Offset, m_Upscaler, m_Downscaler, m_Convolver, Output.Format);
             if (m_Tagged) result.EnableTag();
-            return result.Tagged(Tag);
+            return result;
         }
 
         protected override IFilter<ITextureOutput<ITexture2D>> Optimize()
         {
             if (InputFilter.Output.Size == m_OutputSize && m_Convolver == null)
                 return InputFilter;
-            return this.Tagged(new StringTag(Description(), m_Tagged ? 0 : 10));
+            return this.Labeled(Description(), m_Tagged ? 0 : 10);
         }
 
         public string Description()

--- a/Extensions/Framework/RenderChain/Textures.cs
+++ b/Extensions/Framework/RenderChain/Textures.cs
@@ -15,6 +15,7 @@
 // License along with this library.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Drawing;
@@ -23,14 +24,21 @@ using SharpDX;
 
 namespace Mpdn.Extensions.Framework.RenderChain
 {
-    public class ListOfBool : List<bool>
+    public struct Bools : IEnumerable<bool>
     {
+        private readonly IEnumerable<bool> m_Source;
+
+        public Bools(IEnumerable<bool> source)
+        {
+            m_Source = source;
+        }
+
         /// <summary>
         /// Returns whether all elements are true.
         /// </summary>
         public bool All
         {
-            get { return this.All(x => x); }
+            get { return m_Source.All(x => x); }
         }
 
         /// <summary>
@@ -38,7 +46,17 @@ namespace Mpdn.Extensions.Framework.RenderChain
         /// </summary>
         public bool Any
         {
-            get { return this.Any(x => x); }
+            get { return m_Source.Any(x => x); }
+        }
+
+        public IEnumerator<bool> GetEnumerator()
+        {
+            return m_Source.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 
@@ -99,24 +117,24 @@ namespace Mpdn.Extensions.Framework.RenderChain
                 yield return Depth.CompareTo(b.Depth);
         }
 
-        public static ListOfBool operator <(TextureSize a, TextureSize b)
+        public static Bools operator <(TextureSize a, TextureSize b)
         {
-            return (ListOfBool) a.CompareTo(b).Select(c => c < 0);
+            return new Bools(a.CompareTo(b).Select(c => c < 0));
         }
 
-        public static ListOfBool operator >(TextureSize a, TextureSize b)
+        public static Bools operator >(TextureSize a, TextureSize b)
         {
-            return (ListOfBool) a.CompareTo(b).Select(c => c > 0);
+            return new Bools(a.CompareTo(b).Select(c => c > 0));
         }
 
-        public static ListOfBool operator <=(TextureSize a, TextureSize b)
+        public static Bools operator <=(TextureSize a, TextureSize b)
         {
-            return (ListOfBool) a.CompareTo(b).Select(c => c <= 0);
+            return new Bools(a.CompareTo(b).Select(c => c <= 0));
         }
 
-        public static ListOfBool operator >=(TextureSize a, TextureSize b)
+        public static Bools operator >=(TextureSize a, TextureSize b)
         {
-            return (ListOfBool) a.CompareTo(b).Select(c => c >= 0);
+            return new Bools(a.CompareTo(b).Select(c => c >= 0));
         }
 
         #endregion

--- a/Extensions/Framework/RenderChain/Textures.cs
+++ b/Extensions/Framework/RenderChain/Textures.cs
@@ -23,6 +23,25 @@ using SharpDX;
 
 namespace Mpdn.Extensions.Framework.RenderChain
 {
+    public class ListOfBool : List<bool>
+    {
+        /// <summary>
+        /// Returns whether all elements are true.
+        /// </summary>
+        public bool All
+        {
+            get { return this.All(x => x); }
+        }
+
+        /// <summary>
+        /// Returns whether any element is true.
+        /// </summary>
+        public bool Any
+        {
+            get { return this.Any(x => x); }
+        }
+    }
+
     public struct TextureSize
     {
         public readonly int Width;
@@ -80,24 +99,24 @@ namespace Mpdn.Extensions.Framework.RenderChain
                 yield return Depth.CompareTo(b.Depth);
         }
 
-        public static bool operator <(TextureSize a, TextureSize b)
+        public static ListOfBool operator <(TextureSize a, TextureSize b)
         {
-            return a.CompareTo(b).All(c => c < 0);
+            return (ListOfBool) a.CompareTo(b).Select(c => c < 0);
         }
 
-        public static bool operator >(TextureSize a, TextureSize b)
+        public static ListOfBool operator >(TextureSize a, TextureSize b)
         {
-            return a.CompareTo(b).All(c => c > 0);
+            return (ListOfBool) a.CompareTo(b).Select(c => c > 0);
         }
 
-        public static bool operator <=(TextureSize a, TextureSize b)
+        public static ListOfBool operator <=(TextureSize a, TextureSize b)
         {
-            return a.CompareTo(b).All(c => c <= 0);
+            return (ListOfBool) a.CompareTo(b).Select(c => c <= 0);
         }
 
-        public static bool operator >=(TextureSize a, TextureSize b)
+        public static ListOfBool operator >=(TextureSize a, TextureSize b)
         {
-            return a.CompareTo(b).All(c => c >= 0);
+            return (ListOfBool) a.CompareTo(b).Select(c => c >= 0);
         }
 
         #endregion

--- a/Extensions/Framework/RenderChain/Textures.cs
+++ b/Extensions/Framework/RenderChain/Textures.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Drawing;
 using Mpdn.RenderScript;
 using SharpDX;
@@ -30,7 +31,7 @@ namespace Mpdn.Extensions.Framework.RenderChain
 
         public bool Is3D
         {
-            get { return Depth != 1; }
+            get { return Depth > 1; }
         }
 
         public bool IsEmpty
@@ -44,6 +45,8 @@ namespace Mpdn.Extensions.Framework.RenderChain
             Height = height;
             Depth = depth;
         }
+
+        #region Comparison Operators
 
         public static bool operator ==(TextureSize a, TextureSize b)
         {
@@ -68,16 +71,38 @@ namespace Mpdn.Extensions.Framework.RenderChain
             return obj is TextureSize && Equals((TextureSize)obj);
         }
 
-        public override int GetHashCode()
+        private IEnumerable<int> CompareTo(TextureSize b)
         {
-            unchecked
-            {
-                var hashCode = Width;
-                hashCode = (hashCode * 397) ^ Height;
-                hashCode = (hashCode * 397) ^ Depth;
-                return hashCode;
-            }
+            yield return Width.CompareTo(b.Width);
+            yield return Height.CompareTo(b.Height);
+
+            if (Is3D || b.Is3D)
+                yield return Depth.CompareTo(b.Depth);
         }
+
+        public static bool operator <(TextureSize a, TextureSize b)
+        {
+            return a.CompareTo(b).All(c => c < 0);
+        }
+
+        public static bool operator >(TextureSize a, TextureSize b)
+        {
+            return a.CompareTo(b).All(c => c > 0);
+        }
+
+        public static bool operator <=(TextureSize a, TextureSize b)
+        {
+            return a.CompareTo(b).All(c => c <= 0);
+        }
+
+        public static bool operator >=(TextureSize a, TextureSize b)
+        {
+            return a.CompareTo(b).All(c => c >= 0);
+        }
+
+        #endregion
+
+        #region Conversions
 
         public static implicit operator TextureSize(Size size)
         {
@@ -92,6 +117,19 @@ namespace Mpdn.Extensions.Framework.RenderChain
         public static implicit operator Vector2(TextureSize size)
         {
             return new Vector2(size.Width, size.Height);
+        }
+
+        #endregion
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Width;
+                hashCode = (hashCode * 397) ^ Height;
+                hashCode = (hashCode * 397) ^ Depth;
+                return hashCode;
+            }
         }
     }
 

--- a/Extensions/Framework/Tag.cs
+++ b/Extensions/Framework/Tag.cs
@@ -15,327 +15,265 @@
 // License along with this library.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Mpdn.Extensions.Framework
 {
-    public interface ITagged
+    public interface ITaggedProcess
     {
-        ProcessTag Tag { get; }
+        IProcessData ProcessData { get; }
     }
 
-    public abstract class ProcessTag
+    public interface IUnionTree<TData> : IEnumerable<TData>
     {
-        public static readonly ProcessTag BOTTOM = new BottomTag();
+        ISet<TData> Set { get; }
 
-        public abstract string Label { get; }
+        int Depth { get; set; }
+        IUnionTree<TData> Root { get; set; }
 
-        public abstract int Verbosity { get; }
+        void MergeWith(IUnionTree<TData> tree);
+    }
 
-        #region Base Implementation
+    public interface IProcessData
+    {
+        IUnionTree<ProcessTag> TagTree { get; }
+        ISet<ProcessTag> Tags { get; } // => TagTree.Set
 
-        private readonly HashSet<ProcessTag> m_InputTags = new HashSet<ProcessTag>();
+        int InputRank { get; }
+        int Rank { get; set; }
 
-        protected virtual ISet<ProcessTag> InputTags
+        void AddInputs(IEnumerable<IProcessData> inputProcesses);
+    }
+
+    public class UnionTree<TData> : IUnionTree<TData>
+    {
+        public ISet<TData> Set { get { return (m_Root == this) ? (m_Set ?? (m_Set = new HashSet<TData>())) : Root.Set; } }
+
+        public int Depth { get; set; }
+
+        public IUnionTree<TData> Root
         {
-            get { return m_InputTags; }
+            get
+            {
+                if (m_Root != this)
+                    m_Root = m_Root.Root;
+                return m_Root;
+            }
+
+            set
+            {
+                if (value != m_Root && m_Set != null)
+                {
+                    value.Set.UnionWith(m_Set);
+                    m_Set = null;
+                }
+                m_Root = value;
+            }
+        }
+
+        public void MergeWith(IUnionTree<TData> tree)
+        {
+            MergeRoots(Root, tree.Root);
+        }
+
+        #region Implementation
+
+        private IUnionTree<TData> m_Root;
+
+        private ISet<TData> m_Set;
+
+        private static void MergeRoots(IUnionTree<TData> x, IUnionTree<TData> y)
+        {
+            if (x == y)
+                return;
+
+            if (x.Depth < y.Depth)
+                x.Root = y;
+            else if (x.Depth > y.Depth)
+                y.Root = x;
+            else
+            {
+                y.Root = x;
+                x.Depth += 1;
+            }
+        }
+
+        public IEnumerator<TData> GetEnumerator()
+        {
+            return Set.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public UnionTree()
+        {
+            m_Root = this;
         }
 
         #endregion
+    }
 
-        #region Text rendering
+    public struct ProcessTag
+    {
+        public string Label { get; private set; }
 
-#if DEBUG
-        protected const int DefaultVerbosity = 0;
-        protected string TreeDescription { get { return CreateString(100); } }
-#else
-        protected const int DefaultVerbosity = 0;
-#endif
+        public int Verbosity { get; private set; }
 
-        public string CreateString(int verbosity = DefaultVerbosity)
+        public Tuple<int, int> Range()
         {
-            var subNodes = SubGraph(n => n.Verbosity <= verbosity);
-            var nodes = subNodes.Keys;
+            if (m_Start != null)
+                return new Tuple<int, int>(m_Start.Rank, m_End.Rank);
+            else
+                return new Tuple<int, int>(m_End.InputRank, m_End.Rank);
+        }
 
-            var index = subNodes
-                .Select((n, i) => new KeyValuePair<ProcessTag, int>(n.Key, i))
-                .ToDictionary(x => x.Key, x => x.Value);
+        #region Implementation
 
-            var minIndex = subNodes.ToDictionary(x => x.Key, 
-                x => x.Value.Select(n => index[n])
-                    .Aggregate(index[x.Key], Math.Min));
+        private IProcessData m_Start;
 
-            var depth = nodes.ToDictionary(
-                node => node, 
-                node => nodes.Count(n => minIndex[n] < index[node] && index[node] < index[n]));
+        private IProcessData m_End;
 
-            var labels = nodes
+        public override string ToString()
+        {
+            return Label;
+        }
+
+        public ProcessTag(string label, int verbostiy, IProcessData start, IProcessData end)
+        {
+            Label = label;
+            Verbosity = verbostiy;
+            m_Start = start;
+            m_End = end ?? start;
+
+            if (m_End == null)
+                throw new ArgumentNullException("Either 'start' or 'end' needs to be non-null.");
+        }
+
+        #endregion
+    }
+
+    public class ProcessData : IProcessData
+    {
+        public IUnionTree<ProcessTag> TagTree { get; private set; }
+
+        public ISet<ProcessTag> Tags { get { return TagTree.Set; } }
+
+        public int InputRank
+        {
+            get
+            {
+                if (m_InputRank < 0)
+                    foreach (var process in m_InputProcesses)
+                        m_InputRank = Math.Max(m_InputRank, process.Rank);
+                return m_InputRank;
+            }
+        }
+
+        public int Rank
+        {
+            get
+            {
+                if (m_Rank < 0)
+                    m_Rank = InputRank;
+                return m_Rank;
+            }
+
+            set { m_Rank = value; }
+        }
+
+        #region Implementation
+
+        private int m_InputRank = -1;
+
+        private int m_Rank = -1;
+
+        private IList<IProcessData> m_InputProcesses = new List<IProcessData>();
+
+        private void MergeWith(IProcessData process)
+        {
+            TagTree.MergeWith(process.TagTree);
+        }
+
+        public void AddInputs(IEnumerable<IProcessData> inputProcesses)
+        {
+            foreach (var process in inputProcesses)
+            if (process != this)
+            {
+                m_InputProcesses.Add(process);
+                MergeWith(process);
+            }
+        }
+
+        public ProcessData()
+        {
+            TagTree = new UnionTree<ProcessTag>();
+        }
+
+        #endregion
+    }
+    
+    public static class TagHelper
+    {
+        public static void AddTag(this IProcessData processData, ProcessTag tag)
+        {
+            processData.Tags.Add(tag);
+        }
+
+        public static void AddTag(this ITaggedProcess taggedProcess, ProcessTag tag)
+        {
+            taggedProcess.ProcessData.AddTag(tag);
+        }
+
+        public static void AddLabel(this ITaggedProcess taggedProcess, string label, int verbosity = 0, ITaggedProcess start = null)
+        {
+            taggedProcess.AddTag(new ProcessTag(label, String.IsNullOrEmpty(label) ? 1000 : verbosity, start != null ? start.ProcessData : null, taggedProcess.ProcessData));
+        }
+
+        public static TtaggedProcess Tagged<TtaggedProcess>(this TtaggedProcess taggedProcess, ProcessTag tag)
+            where TtaggedProcess : ITaggedProcess
+        {
+            taggedProcess.AddTag(tag);
+            return taggedProcess;
+        }
+
+        public static TtaggedProcess Labeled<TtaggedProcess>(this TtaggedProcess taggedProcess, string label, int verbosity = 0, ITaggedProcess start = null)
+            where TtaggedProcess : ITaggedProcess
+        {
+            taggedProcess.AddLabel(label, verbosity, start);
+            return taggedProcess;
+        }
+
+        #region String Generation
+
+        private const int DefaultVerbosity = 0;
+
+        public static string CreateString(this IProcessData data, int verbosity = DefaultVerbosity)
+        {
+            var tags = data.Tags.Where(t => (t.Verbosity <= verbosity)).ToList();
+
+            var range = tags.ToDictionary(
+                tag => tag,
+                tag => tag.Range());
+
+            tags = tags.Where(t => (range[t].Item1 < range[t].Item2)).ToList();
+
+            var depth = tags.ToDictionary(
+                tag => tag,
+                tag => tags.Count(t => 
+                        range[t].Item1 <= range[tag].Item1 && range[tag].Item2 <= range[t].Item2
+                    && (range[t].Item1 != range[tag].Item1 || range[tag].Item2 != range[t].Item2)));
+
+            var labels = tags
                 .Where(n => -n.Verbosity <= verbosity)
                 .Select(n => String.Concat(Enumerable.Repeat("    ", depth[n])) + n.Label);
             return string.Join("\n", labels);
         }
 
         #endregion
-
-        #region Graph Operations
-
-        protected void AddInput(ProcessTag tag)
-        {
-            InputTags.Add(tag);
-        }
-
-        protected void AddInputs(IEnumerable<ProcessTag> tags)
-        {
-            foreach (var tag in tags)
-                AddInput(tag);
-        }
-
-        protected void RemoveInput(ProcessTag tag)
-        {
-            m_InputTags.Remove(tag);
-        }
-
-        protected void RemoveInputs(IEnumerable<ProcessTag> tags)
-        {
-            foreach (var tag in tags)
-                RemoveInput(tag);
-        }
-
-        public void AddPrefix(ProcessTag prefix)
-        {
-            foreach (var tag in EndNodes())
-                tag.AddInput(prefix);
-        }
-
-        public void Remove(ProcessTag tag)
-        {
-            if (InputTags.Contains(tag))
-            {
-                InputTags.ExceptWith(new []{ tag });
-                AddInputs(tag.InputTags.Except(new [] { tag }));
-            }
-        }
-
-        public void Purge(ProcessTag tag)
-        {
-            foreach (var node in Nodes())
-                node.Remove(tag);
-        }
-
-        public void Insert(ProcessTag tag)
-        {
-            tag.AddPrefix(new HubTag(InputTags.ToArray()));
-            InputTags.Clear();
-            InputTags.Add(tag);
-        }
-
-        public bool IsEndNode()
-        {
-            return !InputTags.Any();
-        }
-
-        public bool HasAncestor(ProcessTag ancestor)
-        {
-            return ancestor.TraverseTree().Contains(this);
-        }
-
-        public bool ConnectedTo(ProcessTag tag)
-        {
-            return tag.HasAncestor(this) || this.HasAncestor(tag);
-        }
-
-        public virtual ISet<ProcessTag> SubGraphNodes(Func<ProcessTag, bool> predicate)
-        {
-            return FilteredGraphInputNodes(predicate);
-        }
-
-        protected virtual IDictionary<ProcessTag, ISet<ProcessTag>> SubGraph(Func<ProcessTag, bool> predicate)
-        {
-            return FilteredGraph(predicate);
-        }
-
-        protected ISet<ProcessTag> FilteredGraphInputNodes(Func<ProcessTag, bool> predicate)
-        {
-            var nodes = new HashSet<ProcessTag>();
-            var visited = new HashSet<ProcessTag>();
-            var ignoredNodes = TraverseIf((tag) =>
-            {
-                if (tag != this && predicate(tag))
-                {
-                    nodes.Add(tag);
-                    return false;
-                }
-
-                if (visited.Contains(tag))
-                    return false;
-
-                visited.Add(tag);
-                return true;
-            }).ToList();
-            return nodes;
-        }
-
-        private IDictionary<ProcessTag, ISet<ProcessTag>> FilteredGraph(Func<ProcessTag, bool> predicate)
-        {
-            return TraverseTree()
-                .Where(predicate)
-                .ToDictionary(node => node, node => node.SubGraphNodes(predicate)); ;
-        }
-
-        #endregion
-
-        #region Node Enumeration
-
-        private IEnumerable<ProcessTag> TraverseIf(Func<ProcessTag, bool> predicate)
-        {
-            if (!predicate(this))
-                yield break;
-
-            foreach (var tag in InputTags)
-                foreach (var node in tag.TraverseIf(predicate))
-                    yield return node;
-
-            yield return this;
-        }
-
-        private IEnumerable<ProcessTag> TraverseTree()
-        {
-            var visited = new HashSet<ProcessTag>();
-            return TraverseIf((tag) =>
-            {
-                if (visited.Contains(tag))
-                    return false;
-
-                visited.Add(tag);
-                return true;
-            });
-        }
-
-        public IList<ProcessTag> Nodes()
-        {
-            return TraverseTree().ToList();
-        }
-
-        public IList<ProcessTag> EndNodes()
-        {
-            return TraverseTree().Where(t => t.IsEndNode()).ToList();
-        }
-
-        #endregion
-
-        #region String Operations
-
-        public override string ToString()
-        {
-            return Label ?? "";
-        }
-
-        public static implicit operator ProcessTag(string label)
-        {
-            return new StringTag(label);
-        }
-
-        #endregion
-
-        private class BottomTag : StringTag
-        {
-            public BottomTag() : base("⊥", -1) { }
-
-            protected override ISet<ProcessTag> InputTags
-            {
-                get { return new HashSet<ProcessTag> {this}; }
-            }
-        }
-    }
-
-    public class EmptyTag : ProcessTag
-    {
-        public override string Label { get { return ""; } }
-
-        public sealed override int Verbosity { get { return 1000; } }
-    }
-
-    public class HubTag : EmptyTag
-    {
-        public HubTag(params ProcessTag[] inputs)
-        {
-            AddInputs(inputs);
-        }
-    }
-
-    public class JunctionTag : ProcessTag
-    {
-        private readonly ProcessTag m_Junction;
-        private readonly ProcessTag m_Description;
-
-        public override string Label { get { return "JUNCTION"; } }
-        public override int Verbosity { get { return -10; } }
-
-        public JunctionTag(ProcessTag description, params ProcessTag[] junctions)
-        {
-            m_Junction = new HubTag(junctions);
-            m_Description = description;
-        }
-
-        public override ISet<ProcessTag> SubGraphNodes(Func<ProcessTag, bool> predicate)
-        {
-            var subNodes = base.SubGraphNodes(predicate);
-            if (predicate(m_Description))
-                subNodes.UnionWith(m_Junction.SubGraphNodes(predicate));
-            return subNodes;
-        }
-    }
-
-    public class StringTag : ProcessTag
-    {
-        private readonly string m_Label;
-        private readonly int m_Verbosity;
-
-        public override string Label
-        {
-            get { return m_Label; }
-        }
-
-        public override int Verbosity
-        {
-            get { return m_Verbosity; }
-        }
-
-        public StringTag(string label, int verbosity = 0)
-        {
-            m_Label = label;
-            m_Verbosity = string.IsNullOrEmpty(label) ? 1000 : verbosity;
-        }
-    }
-
-    public static class TagHelper
-    {
-        public static void AddJunction(this ITagged tagged, ProcessTag description, ITagged input)
-        {
-            tagged.Tag.Insert(new JunctionTag(description, input.Tag));
-            tagged.Tag.Insert(description);
-        }
-
-        public static TTagged GetTag<TTagged>(this TTagged tagged, out ProcessTag tag)
-            where TTagged : ITagged
-        {
-            tag = tagged.Tag;
-            return tagged;
-        }
-
-        public static TTagged Tagged<TTagged>(this TTagged tagged, ProcessTag tag)
-            where TTagged : ITagged
-        {
-            tagged.Tag.Insert(tag);
-            return tagged;
-        }
-
-        public static TTagged PrefixTagTo<TTagged>(this TTagged tagged, ProcessTag tag)
-            where TTagged : ITagged
-        {
-            tag.AddPrefix(tagged.Tag);
-            return tagged;
-        }
     }
 }

--- a/Extensions/PlayerExtensions/DisplayChanger.cs
+++ b/Extensions/PlayerExtensions/DisplayChanger.cs
@@ -56,7 +56,6 @@ namespace Mpdn.Extensions.PlayerExtensions
 
             Player.StateChanged += PlayerStateChanged;
             Player.Closed += FormClosed;
-
             foreach (var screen in Screen.AllScreens)
             {
                 m_AllRefreshRates.Add(GetRefreshRate(screen));

--- a/Extensions/PlayerExtensions/ScriptChainOsdPainter.cs
+++ b/Extensions/PlayerExtensions/ScriptChainOsdPainter.cs
@@ -158,9 +158,7 @@ namespace Mpdn.Extensions.PlayerExtensions
 
         private static string GetInternalScalerDesc()
         {
-            ProcessTag tag = new EmptyTag();
-            VideoSourceFilter.InsertScaleDescription(tag, Renderer.TargetSize);
-            return tag.CreateString();
+            return String.Join("\n", VideoSourceFilter.ScaleDescription(Renderer.TargetSize));
         }
     }
 

--- a/Extensions/RenderScripts/Custom.MyRenderScript.cs
+++ b/Extensions/RenderScripts/Custom.MyRenderScript.cs
@@ -52,12 +52,12 @@ namespace Mpdn.RenderScript
                 // Use NEDI once only.
                 // Note: To use NEDI as many times as required to get the image past target size,
                 //       Change the following *if* to *while*
-                if (IsUpscalingFrom(input)) // See CombinedChain for other comparer methods
+                if (Renderer.TargetSize > input.Size()) // See TextureSize for other comparer methods
                 {
                     input += new Nedi { AlwaysDoubleImage = true };
                 }
 
-                if (IsDownscalingFrom(input))
+                if (Renderer.TargetSize < input.Size())
                 {
                     // Use linear light for downscaling
                     input += new ImageProcessor { ShaderFileNames = ToLinear }

--- a/Extensions/RenderScripts/Custom.MyRenderScript.cs
+++ b/Extensions/RenderScripts/Custom.MyRenderScript.cs
@@ -52,12 +52,12 @@ namespace Mpdn.RenderScript
                 // Use NEDI once only.
                 // Note: To use NEDI as many times as required to get the image past target size,
                 //       Change the following *if* to *while*
-                if (Renderer.TargetSize > input.Size()) // See TextureSize for other comparer methods
+                if ((Renderer.TargetSize > input.Size()).All) // See TextureSize for other comparer methods
                 {
                     input += new Nedi { AlwaysDoubleImage = true };
                 }
 
-                if (Renderer.TargetSize < input.Size())
+                if ((Renderer.TargetSize < input.Size()).All)
                 {
                     // Use linear light for downscaling
                     input += new ImageProcessor { ShaderFileNames = ToLinear }

--- a/Extensions/RenderScripts/DebandExperimental/Deband.hlsl
+++ b/Extensions/RenderScripts/DebandExperimental/Deband.hlsl
@@ -17,82 +17,133 @@
 sampler s0 : register(s0);
 sampler s1 : register(s1);
 sampler s2 : register(s2);
+// sampler sVar : register(s3);
 float4  p0 : register(c0);
 float4 args0 : register(c2);
 float4 size0 : register(c3);
 float4 size1 : register(c4);
 float4 sizeOutput : register(c5);
 
-#define acuity args0[0]
-#define power  args0[1]
+#define range args0[0]
+#define power args0[1]
 
-// #define threshold (power)
-// #define margin 	  sqrt(2*threshold)
+#define acuity ((1-power)/power)
 
-#ifdef PRESERVE_DETAIL
-#define enhance	(0.5*(threshold + 0.5*margin))
-#else
-#define enhance	0
-#endif
+// #define PRESERVE_COLOUR
 
 #ifdef PRESERVE_DETAIL
-#define detail 20
+#define detail (1)
 #else
-#define detail 0
+#define detail (0)
 #endif
 
-#define pi acos(-1)
-#define sqr(x) ((x)*(x))
+#ifdef PRESERVE_COLOUR
+	#define norm(x) (dot((x).xyz,(x).xyz)/3.0)
+#else
+	#define norm(x) sqr(x)
+#endif
+
+#define sqr(x)	pow(x, 2)
 
 #define Get(x,y)    	  (tex2Dlod(s0, float4(size0.zw*(pos + 0.5 + int2(x,y)), 0,0)))
 #define GetResult(x,y)    (tex2Dlod(s2, float4(size0.zw*(pos + 0.5 + int2(x,y)), 0,0)))
 
 float4 main(float2 tex : TEXCOORD0) : COLOR {
-    // Calculate position
+	float4 value = tex2D(s1, tex);
+	// float4 var = tex2D(sVar, tex);
+
+	// Calculate position
 	float2 pos = tex * size0.xy - 0.5;
-	float2 offset = pos - floor(pos);
+	float2 offset = pos - clamp(floor(pos), 0, size0.xy - 2);
 	pos -= offset;
 
-	float4 value = tex2D(s1, tex);
+	// // Calculate position
+	// float2 pos = tex * size0.xy - 0.5;
+	// float2 offset = pos - floor(pos);
+	// pos = floor(pos);
 
-	float4 weights;
+	float4x2 grad = 0;
+	float4 mean = 0;
+	float4 mean2 = 0;
+	float4 result = 0;
+	float4 totalWeight = 0;
+	float4 totalWeight2 = 0;
 	for (int x=0; x<2; x++)
 	for (int y=0; y<2; y++) {
-		float3 d = (value - Get(x,y))*acuity;
-		weights[y + 2*x] = 1 / (1 + 0.5*dot(d,d));
-	}
-	weights /= dot(weights, 1);
+		float4 d = max(0, abs(value - Get(x,y)) * acuity * range - 1);
+		float2 k = saturate(1 - abs(offset - float2(x,y)));
+		float4 w = k.x * k.y / (1 + norm(d));
 
-	// float4 mean = lerp(
-	// 	lerp(Get(0,0), Get(1,0), offset.x),
-	// 	lerp(Get(0,1), Get(1,1), offset.x), offset.y);
-	// float4 result = lerp(
-	// 	lerp(GetResult(0,0), GetResult(1,0), offset.x),
-	// 	lerp(GetResult(0,1), GetResult(1,1), offset.x), offset.y);
-
-	float4 mean = 0; float4 result = 0;
-	for (int x=0; x<2; x++)
-	for (int y=0; y<2; y++) {
-		float w = weights[y + 2*x];
+		grad += mul(float4x1(Get(x,y) / (1 + norm(d))), float1x2( (abs(offset - float2(x,y)) < 1 ? sign(offset - float2(x,y)) : 0) * float2(k.y, k.x) ));
+		mean2 += w*sqr(Get(x,y) - value);
 		mean += w*Get(x,y);
 		result += w*GetResult(x,y);
+		totalWeight += w;
 	}
+	grad /= transpose(float2x4(totalWeight, totalWeight));
+	mean /= totalWeight;
+	mean2 /= totalWeight;
+	result /= totalWeight;
+
+	// float4 var = (mean2 - sqr(mean - value)) / (1 - totalWeight2 / sqr(totalWeight));
 
 	float4 lo = min(min(Get(0,0), Get(1,0)), min(Get(0,1), Get(1,1)));
 	float4 hi = max(max(Get(0,0), Get(1,0)), max(Get(0,1), Get(1,1)));
 
+	// float4 mean = lerp(
+	// 	lerp(Get(0,0), Get(1,0), offset.x), 
+	// 	lerp(Get(0,1), Get(1,1), offset.x), offset.y);
+	// float4 result = lerp(
+	// 	lerp(GetResult(0,0), GetResult(1,0), offset.x), 
+	// 	lerp(GetResult(0,1), GetResult(1,1), offset.x), offset.y);
+
+	// // Load input
+	// float4x4 X = {Get(0,0), Get(1,0), Get(0,1), Get(1,1)};
+	// float4x4 Y = {GetResult(0,0), GetResult(1,0), GetResult(0,1), GetResult(1,1)};
+	
+	// // Use linear regression to interpolate
+	// float3x4 LinFit = {{-0.5, 0.5, -0.5, 0.5}, {-0.5, -0.5, 0.5, 0.5}, {0.25, 0.25, 0.25, 0.25}};
+	// float4 w = mul(float1x3(offset-0.5,1), LinFit);
+	
+	// float4 mean = mul(w, X);
+	// float4 result = mul(w, Y);
+
+	// Calculate gradient
+	// float4x2 grad = transpose(mul(float2x4(LinFit[0], LinFit[1]), X));
+	// float4 grad2 = float4(dot(grad[0], grad[0]), dot(grad[1], grad[1]), dot(grad[2], grad[2]), dot(grad[3], grad[3]));
+
+// #ifdef PRESERVE_COLOUR
+// 	grad2 = dot(grad2.xyz, 1.0/3.0);
+// #endif
+
 	float4 diff = (value - mean);
 
-#define threshold(x) ((x)*(1 - power) < power)
-#define soft_threshold(x) (1 - saturate((x)*(1-power)/power - 1))
-	// diff = threshold((hi - lo)*acuity) && threshold(abs(diff)*acuity) && threshold((lo - value)*acuity*detail) && threshold((value - hi)*acuity*detail) ? 0 : diff;
-	float4 error = 
-		soft_threshold((hi - lo)*acuity)
-		* soft_threshold(abs(diff)*acuity)
-		* soft_threshold(detail*(lo - value)*acuity)
-		* soft_threshold(detail*(value - hi)*acuity);
-	diff = lerp(diff, 0, error);
-	// diff = (diff + enhance/((diff*acuity)*acuity)) * smoothstep(threshold, threshold + margin, abs(diff)*acuity);
+	// diff += sign(diff) * (1 / max(diff*acuity, 1) - 1) / acuity;
+
+#define detail_check(x) saturate(1 - (x) * (2 * range * detail))
+#define sanity_check(x) saturate(1 - (x))
+// #define banding_check(x) saturate(1 / ((x) * sqr(range * acuity)))
+#define banding_check(x) (1 - saturate((x) * range * acuity - 1))
+	float4 LBanding = 1
+		// * banding_check(var / 0.25)
+		// * banding_check(grad2)
+		* banding_check(hi - lo)
+		// * banding_check(hi - value)
+		// * banding_check(value - lo)
+		// * sanity_check(mean.w a sqr(range * acuity))
+		// * sanity_check(10 * mean.w / sqr(hi - lo))
+		// * sanity_check(10 * mean.w / (sqr(diff) + 1/sqr(range * acuity)))
+		// * sanity_check(norm(diff) / norm(hi - lo))
+		// * sanity_check(0.5 + (lo - hi) * range)
+		* sanity_check(norm(diff * range) - sqr(0.5))
+		// * sanity_check(abs(diff * range) - 0.5)
+		// * detail_check(resLo - value)
+		// * detail_check(value - resHi);
+		* detail_check(lo - value)
+		* detail_check(value - hi);
+	float prior = 1 - 0.95;
+	diff = lerp(diff, 0, (LBanding * prior) / (LBanding * prior + (1 - LBanding) * (1 - prior)));
+	// diff = lerp(diff, 0, smoothstep(0.90, 0.95, LBanding));
 
 	// Reconstruct Gaussian pyramid
 	return result + diff;

--- a/Extensions/RenderScripts/DebandExperimental/Downscale.hlsl
+++ b/Extensions/RenderScripts/DebandExperimental/Downscale.hlsl
@@ -14,21 +14,23 @@
 // You should have received a copy of the GNU Lesser General Public
 // License along with this library.
 
-sampler s0 : register(s0);
-float4  p0 : register(c0);
-float4 args0 : register(c2);
-float4 size0 : register(c3);
-float4 sizeOutput : register(c5);
+sampler s0   : register(s0);
+float4  p0   : register(c0);
+float4 size0 : register(c2);
+float4 args0 : register(c3);
+float4 sizeOutput : register(c4);
+float  iteration  : register(c5);
+
+#define range args0[0]
+#define power args0[1]
 
 #define dxdy size0.zw
 
-#define acuity 255.0//args0[0]
-#define power  args0[1]
-
 #define pi acos(-1)
+#define phi ((1+sqrt(5))/2)
 #define sqr(x) ((x)*(x))
 
-#define factor ((size0.xy / sizeOutput.xy))
+#define factor (size0.xy / sizeOutput.xy)
 
 #define Kernel(x) saturate(0.5 + (0.5 - abs(x)) / factor)
 
@@ -43,15 +45,18 @@ float4 main(float2 tex : TEXCOORD0) : COLOR{
 
 	float totalWeight = 0;
 	float4 total = 0;
+
 	for (int X=-1; X<=1; X++)
 	for (int Y=-1; Y<=1; Y++) {
 		float2 kernel = Kernel(float2(X,Y) - offset);
 		float weight = kernel.x * kernel.y;
+		float4 sample = Get(X,Y);
 
-		total += weight * Get(X,Y);
+		total += weight * sample;
 		totalWeight += weight;
 	}
 	total /= totalWeight;
+	// total.w = totalVar;
 
 	return total;
 }

--- a/Extensions/RenderScripts/DebandExperimental/DownscaleLuma.hlsl
+++ b/Extensions/RenderScripts/DebandExperimental/DownscaleLuma.hlsl
@@ -1,0 +1,30 @@
+// This file is a part of MPDN Extensions.
+// https://github.com/zachsaw/MPDN_Extensions
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+// 
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library.
+
+#define main Downscale
+#include "Downscale.hlsl"
+#undef main
+
+sampler s1   : register(s1);
+
+float4 main(float2 tex : TEXCOORD0) : COLOR{
+	float4 result = Downscale(tex);
+
+	// Copy Chroma
+	result.yz = tex2D(s1, tex).yz;
+
+	return result;
+}

--- a/Extensions/RenderScripts/Hylian.Super-xBR.cs
+++ b/Extensions/RenderScripts/Hylian.Super-xBR.cs
@@ -54,8 +54,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var pass2 = CompileShader("super-xbr.hlsl", entryPoint: "main_fragment", macroDefinitions: "Pass = 2;" + fastToggle).Configure(arguments: arguments);
 
                 // Skip if downscaling
-                if (Renderer.TargetSize.Width  <= input.Size().Width 
-                 && Renderer.TargetSize.Height <= input.Size().Height)
+                if (!(Renderer.TargetSize.Width > input.Size())
                     return input;
 
                 ITextureFilter xbr = input

--- a/Extensions/RenderScripts/Hylian.Super-xBR.cs
+++ b/Extensions/RenderScripts/Hylian.Super-xBR.cs
@@ -54,7 +54,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var pass2 = CompileShader("super-xbr.hlsl", entryPoint: "main_fragment", macroDefinitions: "Pass = 2;" + fastToggle).Configure(arguments: arguments);
 
                 // Skip if downscaling
-                if (!(Renderer.TargetSize.Width > input.Size())
+                if (!(Renderer.TargetSize > input.Size()))
                     return input;
 
                 ITextureFilter xbr = input

--- a/Extensions/RenderScripts/Hylian.Super-xBR.cs
+++ b/Extensions/RenderScripts/Hylian.Super-xBR.cs
@@ -54,7 +54,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var pass2 = CompileShader("super-xbr.hlsl", entryPoint: "main_fragment", macroDefinitions: "Pass = 2;" + fastToggle).Configure(arguments: arguments);
 
                 // Skip if downscaling
-                if (!(Renderer.TargetSize > input.Size()))
+                if ((Renderer.TargetSize <= input.Size()).Any)
                     return input;
 
                 ITextureFilter xbr = input

--- a/Extensions/RenderScripts/Hylian.Super-xBR.cs
+++ b/Extensions/RenderScripts/Hylian.Super-xBR.cs
@@ -54,8 +54,8 @@ namespace Mpdn.Extensions.RenderScripts
                 var pass2 = CompileShader("super-xbr.hlsl", entryPoint: "main_fragment", macroDefinitions: "Pass = 2;" + fastToggle).Configure(arguments: arguments);
 
                 // Skip if downscaling
-                if (Renderer.TargetSize.Width  <= input.Output.Size.Width 
-                 && Renderer.TargetSize.Height <= input.Output.Size.Height)
+                if (Renderer.TargetSize.Width  <= input.Size().Width 
+                 && Renderer.TargetSize.Height <= input.Size().Height)
                     return input;
 
                 ITextureFilter xbr = input
@@ -64,7 +64,7 @@ namespace Mpdn.Extensions.RenderScripts
 
                 return ThirdPass
                     ? (ITextureFilter) xbr.Apply(pass2)
-                    : xbr.Resize(xbr.Output.Size, offset: new Vector2(0.5f, 0.5f));
+                    : xbr.Resize(xbr.Size(), offset: new Vector2(0.5f, 0.5f));
             }
 
             protected override string ShaderPath

--- a/Extensions/RenderScripts/Mpdn.DxvaHd.Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.DxvaHd.Scaler.cs
@@ -96,12 +96,12 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override ITextureFilter CreateFilter(ITextureFilter sourceFilter)
             {
-                if (sourceFilter.Output.Size == Renderer.TargetSize)
+                if (sourceFilter.Size() == Renderer.TargetSize)
                     return sourceFilter;
 
                 try
                 {
-                    m_DxvaHd = Renderer.CreateDxvaHd((Size) sourceFilter.Output.Size, TextureFormat.Unorm8,
+                    m_DxvaHd = Renderer.CreateDxvaHd((Size) sourceFilter.Size(), TextureFormat.Unorm8,
                         Renderer.TargetSize, TextureFormat.Unorm8, Quality);
                 }
                 catch (DxvaHdException)

--- a/Extensions/RenderScripts/Mpdn.EwaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaScaler.cs
@@ -78,7 +78,7 @@ namespace Mpdn.Extensions.RenderScripts
             protected override ITextureFilter CreateFilter(ITextureFilter input)
             {
                 var sourceSize = input.Size();
-                if (!(Renderer.TargetSize > sourceSize))
+                if ((Renderer.TargetSize <= sourceSize).Any)
                     return input;
 
                 var targetSize = Renderer.TargetSize;

--- a/Extensions/RenderScripts/Mpdn.EwaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaScaler.cs
@@ -78,7 +78,7 @@ namespace Mpdn.Extensions.RenderScripts
             protected override ITextureFilter CreateFilter(ITextureFilter input)
             {
                 var sourceSize = input.Size();
-                if ((Renderer.TargetSize < sourceSize).Any())
+                if (!(Renderer.TargetSize > sourceSize))
                     return input;
 
                 var targetSize = Renderer.TargetSize;

--- a/Extensions/RenderScripts/Mpdn.EwaScaler.cs
+++ b/Extensions/RenderScripts/Mpdn.EwaScaler.cs
@@ -77,8 +77,8 @@ namespace Mpdn.Extensions.RenderScripts
 
             protected override ITextureFilter CreateFilter(ITextureFilter input)
             {
-                var sourceSize = input.Output.Size;
-                if (!IsUpscalingFrom(sourceSize))
+                var sourceSize = input.Size();
+                if ((Renderer.TargetSize < sourceSize).Any())
                     return input;
 
                 var targetSize = Renderer.TargetSize;

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Chroma.Nnedi3Scaler.cs
@@ -90,11 +90,11 @@ namespace Mpdn.Extensions.RenderScripts
                     return null; // OpenCL is not available; fallback
                 }
 
-                var lumaSize = lumaInput.Output.Size;
-                var chromaSize = chromaInput.Output.Size;
+                var lumaSize = composition.Luma.Size();
+                var chromaSize = composition.Chroma.Size();
 
-                if (lumaSize.Width != 2*chromaSize.Width || lumaSize.Height != 2*chromaSize.Height)
-                    return null; // Chroma shouldn't be doubled; fallback
+                if (lumaSize.Width != 2 * chromaSize.Width || lumaSize.Height != 2 * chromaSize.Height)
+                    return composition; // Chroma shouldn't be doubled; fallback
 
                 Func<TextureSize, TextureSize> transformWidth = s => new TextureSize(2 * s.Width, s.Height);
                 Func<TextureSize, TextureSize> transformHeight = s => new TextureSize(s.Width, 2 * s.Height);

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
@@ -209,24 +209,23 @@ namespace Mpdn.Extensions.RenderScripts
                     buffer2 = Renderer.CreateClBuffer(weights2);
                 }
 
-                var sourceSize = input.Output.Size;
-                if (!IsUpscalingFrom(sourceSize))
+                var sourceSize = input.Size();
+                if (!(Renderer.TargetSize > sourceSize))
                     return input;
 
                 var yuv = input.ConvertToYuv();
 
                 var localWorkSizes = new[] {8, 8};
                 var nnedi3H = new NNedi3HKernelFilter(shaderH, buffer1, neuronCount1,
-                    new TextureSize(yuv.Output.Size.Width, yuv.Output.Size.Height), 
+                    new TextureSize(yuv.Size().Width, yuv.Size().Height), 
                     localWorkSizes, yuv);
                 var nnedi3V = new NNedi3VKernelFilter(shaderV, buffer2, neuronCount2, differentWeights,
-                    new TextureSize(nnedi3H.Output.Size.Width, nnedi3H.Output.Size.Height), 
+                    new TextureSize(nnedi3H.Size().Width, nnedi3H.Size().Height), 
                     localWorkSizes, nnedi3H);
 
                 var result = ChromaScaler.MakeChromaFilter(nnedi3V, yuv, chromaOffset: new Vector2(-0.25f, -0.25f));
 
-                return new ResizeFilter(result, result.Output.Size, new Vector2(0.5f, 0.5f),
-                    Renderer.LumaUpscaler, Renderer.LumaDownscaler);
+                return new ResizeFilter(result, result.Size(), new Vector2(0.5f, 0.5f), Renderer.LumaUpscaler, Renderer.LumaDownscaler);
             }
         }
 

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
@@ -210,7 +210,7 @@ namespace Mpdn.Extensions.RenderScripts
                 }
 
                 var sourceSize = input.Size();
-                if (!(Renderer.TargetSize > sourceSize))
+                if ((Renderer.TargetSize <= sourceSize).Any)
                     return input;
 
                 var yuv = input.ConvertToYuv();

--- a/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
+++ b/Extensions/RenderScripts/Mpdn.OclNnedi3.Nnedi3Scaler.cs
@@ -223,7 +223,8 @@ namespace Mpdn.Extensions.RenderScripts
                     new TextureSize(nnedi3H.Size().Width, nnedi3H.Size().Height), 
                     localWorkSizes, nnedi3H);
 
-                var result = ChromaScaler.MakeChromaFilter(nnedi3V, yuv, chromaOffset: new Vector2(-0.25f, -0.25f));
+                var result = ChromaScaler.ScaleChroma(
+                    new CompositionFilter(nnedi3V, yuv, targetSize: nnedi3V.Size(), chromaOffset: new Vector2(-0.25f, -0.25f)));
 
                 return new ResizeFilter(result, result.Size(), new Vector2(0.5f, 0.5f), Renderer.LumaUpscaler, Renderer.LumaDownscaler);
             }

--- a/Extensions/RenderScripts/SSimDownscaler/CalcR.hlsl
+++ b/Extensions/RenderScripts/SSimDownscaler/CalcR.hlsl
@@ -4,6 +4,11 @@ sampler sH:	register(s2);
 
 #define AverageFormat float2x4
 
+#define Kernel(x) pow(0.25, abs(x))
+#define taps 3	
+#define maxtaps taps
+#define Correction (1 - (1 + 4*pow(Kernel(1), 2) + 4 * pow(Kernel(2),2)) / pow(1 + 4*Kernel(1) + 4*Kernel(2), 2))
+
 // -- Define horizontal convolver --
 #define EntryPoint ScaleH
 #define sqr(x)	((x)*(x))
@@ -22,6 +27,7 @@ sampler sH:	register(s2);
 #define EntryPoint 			main
 #define Initialization		float4 mean = tex2D(sMean, tex)
 #define Get(pos) 			ScaleH(pos, mean)
-#define PostProcessing(S)	(S[0] == 0) ? 0 : sqrt(1 + S[1] / S[0])
+#define PostProcessing(S)	(S[0] == 0) ? 0 : sqrt(1 + S[1] * Correction / S[0])
+// #define PostProcessing(S)	(S[0] == 0) ? 0 : sqrt(1 + S[1] / S[0])
 #define axis 1
 #include "./Scalers/Convolver.hlsl"

--- a/Extensions/RenderScripts/SSimDownscaler/SinglePassConvolver.hlsl
+++ b/Extensions/RenderScripts/SSimDownscaler/SinglePassConvolver.hlsl
@@ -1,3 +1,7 @@
+#define Kernel(x) pow(0.25, abs(x))
+#define taps 3	
+#define maxtaps taps
+
 // -- Define horizontal convolver --
 #define EntryPoint ScaleH
 #define axis 0

--- a/Extensions/RenderScripts/Shiandow.Bilateral.cs
+++ b/Extensions/RenderScripts/Shiandow.Bilateral.cs
@@ -72,7 +72,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var chromaOffset = composition.ChromaOffset;
 
                 // Fall back to default when downscaling is needed
-                if (!(chromaSize <= targetSize) || chromaSize == targetSize)
+                if ((chromaSize > targetSize).Any || chromaSize == targetSize)
                     return composition;
 
                 Vector2 adjointOffset = -(chromaOffset * lumaSize) / chromaSize;

--- a/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Chroma.ChromaScaler.cs
@@ -93,7 +93,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var targetSize = composition.TargetSize;
 
                 // Fall back to default when downscaling is needed
-                if (!(chromaSize <= targetSize) || chromaSize == targetSize)
+                if ((chromaSize > targetSize).Any || chromaSize == targetSize)
                     return composition;
 
                 Vector2 offset = composition.ChromaOffset + new Vector2(0.5f, 0.5f);

--- a/Extensions/RenderScripts/Shiandow.Deband.cs
+++ b/Extensions/RenderScripts/Shiandow.Deband.cs
@@ -53,7 +53,7 @@ namespace Mpdn.Extensions.RenderScripts
                     .Configure(arguments: consts, perTextureLinearSampling: new[] { true, false });
 
                 ITextureFilter yuv = input.ConvertToYuv();
-                var inputsize = yuv.Output.Size;
+                var inputsize = yuv.Size();
 
                 var deband = yuv;
                 double factor = 2.0;// 0.5 * Math.Sqrt(5) + 0.5;

--- a/Extensions/RenderScripts/Shiandow.DebandExperimental.cs
+++ b/Extensions/RenderScripts/Shiandow.DebandExperimental.cs
@@ -20,6 +20,7 @@ using Mpdn.Extensions.Framework;
 using Mpdn.Extensions.Framework.RenderChain;
 using Mpdn.Extensions.Framework.RenderChain.Shader;
 using Mpdn.RenderScript;
+using Mpdn.Extensions.Framework.RenderChain.TextureFilter;
 
 namespace Mpdn.Extensions.RenderScripts
 {
@@ -42,6 +43,9 @@ namespace Mpdn.Extensions.RenderScripts
                 int bits = Renderer.InputFormat.GetBitDepth();
                 if (bits > MaxBitDepth) return input;
 
+                var composition = input as ICompositionFilter;
+                var offset = new SharpDX.Vector2(0.0f, 0.0f); // TODO: process chroma offset properly
+
                 float[] consts = {
                     (1 << bits) - 1,
                     Power
@@ -49,8 +53,16 @@ namespace Mpdn.Extensions.RenderScripts
 
                 var Downscale = new Shader(FromFile("Downscale.hlsl"))
                 {
-                    Transform = s => new TextureSize(s.Width/2, s.Height/2)
+                    Transform = s => new TextureSize(s.Width / 2, s.Height / 2),
+                    Arguments = consts
                 };
+
+                var DownscaleLuma = new Shader(FromFile("DownscaleLuma.hlsl"))
+                {
+                    SizeIndex = 1,
+                    Arguments = consts
+                };
+                DownscaleLuma["iteration"] = 0;
 
                 var Deband = new Shader(FromFile("Deband.hlsl", macroDefinitions: PreserveDetail ? "PRESERVE_DETAIL=1" : ""))
                 {
@@ -59,19 +71,47 @@ namespace Mpdn.Extensions.RenderScripts
                     SizeIndex = 1
                 };
 
-                var deband = input.ConvertToYuv();
+                ITextureFilter deband, chroma = null, luma = null;
                 var pyramid = new Stack<ITextureFilter>();
+
+                if (composition != null)
+                {
+                    deband = composition.Luma;
+                    pyramid.Push(deband);
+                    pyramid.Push(DownscaleLuma.ApplyTo(composition.Luma, composition.Chroma));
+                }
+                else
+                {
+                    deband = input.ConvertToYuv();
+                    pyramid.Push(deband);
+                }
 
                 // Build gaussian pyramid
                 while (pyramid.Peek().Size().Width >= 2
                     && pyramid.Peek().Size().Height >= 2)
+                {
+                    Downscale["iteration"] = pyramid.Count - 1;
                     pyramid.Push(Downscale.ApplyTo(pyramid.Peek()));
+                }
 
+                // Process pyramid
                 var result = pyramid.Peek();
                 while (pyramid.Count > 1)
+                {
                     result = Deband.ApplyTo(pyramid.Pop(), pyramid.Peek(), result);
+                    if (composition != null && pyramid.Count == 2)
+                    {
+                        chroma = result;
+                        Deband.Format = TextureFormat.Unorm16_R;
+                    }
+                }
 
-                return result.ConvertToRgb();
+                if (composition != null)
+                {
+                    luma = result;
+                    return new CompositionFilter(luma, chroma, composition.TargetSize, composition.ChromaOffset);
+                }
+                else return result.ConvertToRgb();
             }
         }
 

--- a/Extensions/RenderScripts/Shiandow.DebandExperimental.cs
+++ b/Extensions/RenderScripts/Shiandow.DebandExperimental.cs
@@ -63,9 +63,8 @@ namespace Mpdn.Extensions.RenderScripts
                 var pyramid = new Stack<ITextureFilter>();
 
                 // Build gaussian pyramid
-                pyramid.Push(deband);
-                while (pyramid.Peek().Output.Size.Width  >= 2
-                    && pyramid.Peek().Output.Size.Height >= 2)
+                while (pyramid.Peek().Size().Width >= 2
+                    && pyramid.Peek().Size().Height >= 2)
                     pyramid.Push(Downscale.ApplyTo(pyramid.Peek()));
 
                 var result = pyramid.Peek();

--- a/Extensions/RenderScripts/Shiandow.Nedi.NediScaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nedi.NediScaler.cs
@@ -42,7 +42,7 @@ namespace Mpdn.Extensions.RenderScripts
 
             private bool UseNedi(ITextureFilter input)
             {
-                var size = input.Output.Size;
+                var size = input.Size();
                 if (size.IsEmpty)
                     return false;
 

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -83,7 +83,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var shaderPass2 = LoadShader11(GetShaderFileName(Neurons2));
                 var interleave = CompileShader("Interleave.hlsl").Configure(transform: transform);
 
-                var sourceSize = input.Output.Size;
+                var sourceSize = input.Size();
                 if (!IsUpscalingFrom(sourceSize))
                     return input;
 

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -84,7 +84,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var interleave = CompileShader("Interleave.hlsl").Configure(transform: transform);
 
                 var sourceSize = input.Size();
-                if (!IsUpscalingFrom(sourceSize))
+                if (!(sourceSize > Renderer.TargetSize))
                     return input;
 
                 var yuv = input.ConvertToYuv();

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -85,7 +85,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var interleave = CompileShader("Interleave.hlsl").Configure(transform: transform);
 
                 var sourceSize = input.Size();
-                if (!(sourceSize > Renderer.TargetSize))
+                if (!(Renderer.TargetSize > sourceSize))
                     return input;
 
                 var yuv = input.ConvertToYuv();

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Mpdn.Extensions.Framework.RenderChain;
+using Mpdn.Extensions.Framework.RenderChain.TextureFilter;
 using Mpdn.Extensions.RenderScripts.Shiandow.NNedi3.Filters;
 using Mpdn.RenderScript;
 using SharpDX;
@@ -94,7 +95,8 @@ namespace Mpdn.Extensions.RenderScripts
                 m_Filter2 = NNedi3Helpers.CreateFilter(shaderPass2, resultY, Neurons2, Structured);
                 var luma = interleave.ApplyTo(resultY, m_Filter2);
 
-                var result = ChromaScaler.MakeChromaFilter(luma, yuv, chromaOffset: new Vector2(-0.25f, -0.25f));
+                var result = ChromaScaler.ScaleChroma(
+                    new CompositionFilter(luma, yuv, targetSize: luma.Size(), chromaOffset: new Vector2(-0.25f, -0.25f)));
 
                 return result.Convolve(null, offset: new Vector2(0.5f, 0.5f));
             }

--- a/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
+++ b/Extensions/RenderScripts/Shiandow.Nnedi3.Scaler.cs
@@ -85,7 +85,8 @@ namespace Mpdn.Extensions.RenderScripts
                 var interleave = CompileShader("Interleave.hlsl").Configure(transform: transform);
 
                 var sourceSize = input.Size();
-                if (!(Renderer.TargetSize > sourceSize))
+
+                if ((Renderer.TargetSize <= sourceSize).Any)
                     return input;
 
                 var yuv = input.ConvertToYuv();

--- a/Extensions/RenderScripts/Shiandow.SSSR.cs
+++ b/Extensions/RenderScripts/Shiandow.SSSR.cs
@@ -150,7 +150,7 @@ namespace Mpdn.Extensions.RenderScripts
                 Diff["oversharp"] = OverSharp;
 
                 // Skip if downscaling
-                if (!(targetSize > inputSize))
+                if ((targetSize <= inputSize).Any)
                     return original;
 
                 // Initial scaling

--- a/Extensions/RenderScripts/Shiandow.SSSR.cs
+++ b/Extensions/RenderScripts/Shiandow.SSSR.cs
@@ -150,7 +150,7 @@ namespace Mpdn.Extensions.RenderScripts
                 Diff["oversharp"] = OverSharp;
 
                 // Skip if downscaling
-                if (targetSize.Width <= inputSize.Width || targetSize.Height <= inputSize.Height)
+                if (!(targetSize > inputSize))
                     return original;
 
                 // Initial scaling

--- a/Extensions/RenderScripts/Shiandow.SSSR.cs
+++ b/Extensions/RenderScripts/Shiandow.SSSR.cs
@@ -131,7 +131,7 @@ namespace Mpdn.Extensions.RenderScripts
                 ITextureFilter result;
 
                 // Calculate Sizes
-                var inputSize = original.Output.Size;
+                var inputSize = original.Size();
                 var targetSize = TargetSize();
 
                 // Compile Shaders

--- a/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
+++ b/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
@@ -71,7 +71,7 @@ namespace Mpdn.Extensions.RenderScripts
                 ITextureFilter H = input, Sh, L, M, R;
                 var targetSize = Renderer.TargetSize;
 
-                if (!IsDownscalingFrom(input))
+                if (!(Renderer.TargetSize > input.Size()))
                     return input;
 
                 var Calc = CompileShader("calc.hlsl");

--- a/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
+++ b/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
@@ -71,7 +71,7 @@ namespace Mpdn.Extensions.RenderScripts
                 ITextureFilter H = input, Sh, L, M, R;
                 var targetSize = Renderer.TargetSize;
 
-                if (!(Renderer.TargetSize > input.Size()))
+                if (!(Renderer.TargetSize < input.Size()))
                     return input;
 
                 var Calc = CompileShader("calc.hlsl");

--- a/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
+++ b/Extensions/RenderScripts/Shiandow.SSimDownscaling.cs
@@ -71,7 +71,7 @@ namespace Mpdn.Extensions.RenderScripts
                 ITextureFilter H = input, Sh, L, M, R;
                 var targetSize = Renderer.TargetSize;
 
-                if (!(Renderer.TargetSize < input.Size()))
+                if ((Renderer.TargetSize >= input.Size()).Any)
                     return input;
 
                 var Calc = CompileShader("calc.hlsl");

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -144,7 +144,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var LinearToLab = CompileShader("../Common/LinearToLab.hlsl");
 
                 // Skip if downscaling
-                if (!(targetSize > inputSize))
+                if ((targetSize <= inputSize).Any)
                     return original;
 
                 // Initial scaling

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -144,7 +144,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var LinearToLab = CompileShader("../Common/LinearToLab.hlsl");
 
                 // Skip if downscaling
-                if (targetSize.Width <= inputSize.Width && targetSize.Height <= inputSize.Height)
+                if (!(targetSize > inputSize))
                     return original;
 
                 // Initial scaling

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -100,7 +100,7 @@ namespace Mpdn.Extensions.RenderScripts
 
             private ITextureFilter DownscaleAndDiff(ITextureFilter input, ITextureFilter original, TextureSize targetSize)
             {
-                var HDownscaler = CompileShader("../SSimDownscaler/Scalers/Downscaler.hlsl", macroDefinitions: "axis = 0;")
+                var HDownscaler = CompileShader("Downscale.hlsl", macroDefinitions: "axis = 0;")
                     .Configure(transform: s => new TextureSize(targetSize.Width, s.Height));
                 var VDownscaleAndDiff = CompileShader("DownscaleAndDiff.hlsl", macroDefinitions: "axis = 1;")
                     .Configure(transform: s => new TextureSize(s.Width, targetSize.Height))
@@ -158,7 +158,7 @@ namespace Mpdn.Extensions.RenderScripts
                     result = initial.SetSize(targetSize).Apply(GammaToLinear);
                 }
                 else
-                    result = original.Apply(GammaToLinear).Resize(targetSize);
+                    result = original.Apply(GammaToLinear).Resize(targetSize, tagged: true);
 
                 for (int i = 1; i <= Passes; i++)
                 {

--- a/Extensions/RenderScripts/Shiandow.SuperRes.cs
+++ b/Extensions/RenderScripts/Shiandow.SuperRes.cs
@@ -118,7 +118,7 @@ namespace Mpdn.Extensions.RenderScripts
                 var HQDownscaler = (IScaler)new Bicubic(0.75f, false);
 
                 // Calculate Sizes
-                var inputSize = original.Output.Size;
+                var inputSize = original.Size();
                 var targetSize = TargetSize();
 
                 string macroDefinitions = "";


### PR DESCRIPTION
## Framework Changes

New method for chroma scaling (doesn't require too many changes to existing chroma scalers). Allows filters to treat Luma and Chroma channels separately if so desired (see DebandExperimental).

Tag system: changed, again. This time to a more foolproof system.

Filter: Disposing accidentally took exponential time, fixed to linear time.

TextureSize: Add comparison methods, remove IsUpscalingFrom, IsDownscalignFrom in favour of more explicit inequality operators. Operators return true when inequality is true for all dimensions.

## Audio/Video Scripts

DebandExperimental: tweaks, allow debanding to be done *before* chroma scaling, improving quality.

SSIMdownscaling: minor tweak

Crossfeed: new audio crossfeed. More of an experiment, and to demonstrate the relative ease with which you can process audio (although actually producing good sounding audio is obviously still black magic).