### PR TITLE
Fix incorrect RemoveFile method

### DIFF
--- a/Extensions/PlayerExtensions/PlaylistForm.cs
+++ b/Extensions/PlayerExtensions/PlaylistForm.cs
@@ -1294,8 +1294,10 @@ namespace Mpdn.Extensions.PlayerExtensions.Playlist
             if (index < 0 || index >= Playlist.Count)
                 return;
 
+            var currentItemIndex = Playlist.IndexOf(CurrentItem);
             Playlist.RemoveAt(index);
-            if (index == Playlist.Count) CloseMedia();
+
+            if (index == currentItemIndex) CloseMedia();
             PopulatePlaylist();
         }
 


### PR DESCRIPTION
- The Playlist RemoveFile method stops media playback if the last item in the playlist is removed. This should not occur, playback should instead stop if the removed item is the currently playing file from the playlist (this logic is invoked by the RemoteControl extension, not the playlist itself)